### PR TITLE
Added two rows (new feature/report bug) to SettingsView

### DIFF
--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -46,6 +46,12 @@
     "Profile" : {
 
     },
+    "Report a Bug" : {
+
+    },
+    "Request a New Feature" : {
+
+    },
     "Settings" : {
 
     },

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -31,6 +31,26 @@ struct SettingsView: View {
                             .resizable()
                             .frame(width: 20, height: 20)
                     }
+                }        
+
+                Link(destination: URL(string: "https://github.com/mikaelacaron/Basic-Car-Maintenance/issues/new?assignees=&labels=feature+request&projects=&template=feature-request.md&title=FEATURE+-")!) {
+                    Label {
+                        Text("Request a New Feature")
+                    } icon: {
+                        Image(systemName: "doc.badge.plus")
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                    }
+                }
+
+                Link(destination: URL(string: "https://github.com/mikaelacaron/Basic-Car-Maintenance/issues/new?assignees=&labels=bug&projects=&template=bug-report.md&title=BUG+-")!) {
+                    Label {
+                        Text("Report a Bug")
+                    } icon: {
+                        Image(systemName: "ladybug")
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                    }
                 }
                 
                 Section {


### PR DESCRIPTION
# What it Does
* Closes issue #18 
* Added a row for GitHub users to submit new feature requests, and a row to report bugs  in SettingsView

# How I Tested
* Add a list of steps to show the functionality of your feature
For example:
* Run the application
* Tap on all three rows including GitHub Repo
* All work as expected, taking the user to Safari to an appropriate link

# Notes
* Haven't added my team ID, as I am still battling with Apple to enroll into the dev program

# Screenshots
<img src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/66741910/248a8458-d6e0-4083-986d-3030cd6662e2" width="250"  />

<img src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/66741910/e4eaafb2-d56f-4fef-9446-6a4d3865da6c" width="250"  />

<img src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/66741910/117b8fd2-e8db-46ad-8968-a867a49cb3e1" width="250"  />


