### PR TITLE
Fixed the bug, which was causing the vehicles, with no details added

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -53,7 +53,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Basic-Car-Maintenance.xcconfig"; sourceTree = SOURCE_ROOT; };
 		FF09FC902AB6FF44006BE61A /* AuthenticationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationView.swift; sourceTree = "<group>"; };
 		FF3DDF512AA4D28F009D91C4 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		FF5D13A32A86C2D600BC9BD6 /* Basic-Car-Maintenance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Basic-Car-Maintenance.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -132,7 +131,6 @@
 		FF5D139A2A86C2D500BC9BD6 = {
 			isa = PBXGroup;
 			children = (
-				FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */,
 				FF5D13A52A86C2D600BC9BD6 /* Basic-Car-Maintenance */,
 				FF5D13B72A86C2D800BC9BD6 /* Basic-Car-MaintenanceTests */,
 				FF5D13C12A86C2D800BC9BD6 /* Basic-Car-MaintenanceUITests */,
@@ -480,7 +478,6 @@
 /* Begin XCBuildConfiguration section */
 		FF5D13C62A86C2D800BC9BD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -542,7 +539,6 @@
 		};
 		FF5D13C72A86C2D800BC9BD6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07367C462ACA021F00A558ED /* Basic-Car-Maintenance.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 07367C452ACA021F00A558ED /* Basic-Car-Maintenance.xcconfig */; };
 		FF09FC912AB6FF44006BE61A /* AuthenticationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09FC902AB6FF44006BE61A /* AuthenticationView.swift */; };
 		FF3DDF522AA4D28F009D91C4 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3DDF512AA4D28F009D91C4 /* DashboardViewModel.swift */; };
 		FF5D13A72A86C2D600BC9BD6 /* BasicCarMaintenanceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5D13A62A86C2D600BC9BD6 /* BasicCarMaintenanceApp.swift */; };
@@ -53,6 +54,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		07367C452ACA021F00A558ED /* Basic-Car-Maintenance.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Basic-Car-Maintenance.xcconfig"; sourceTree = "<group>"; };
 		FF09FC902AB6FF44006BE61A /* AuthenticationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationView.swift; sourceTree = "<group>"; };
 		FF3DDF512AA4D28F009D91C4 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		FF5D13A32A86C2D600BC9BD6 /* Basic-Car-Maintenance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Basic-Car-Maintenance.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -131,6 +133,7 @@
 		FF5D139A2A86C2D500BC9BD6 = {
 			isa = PBXGroup;
 			children = (
+				07367C452ACA021F00A558ED /* Basic-Car-Maintenance.xcconfig */,
 				FF5D13A52A86C2D600BC9BD6 /* Basic-Car-Maintenance */,
 				FF5D13B72A86C2D800BC9BD6 /* Basic-Car-MaintenanceTests */,
 				FF5D13C12A86C2D800BC9BD6 /* Basic-Car-MaintenanceUITests */,
@@ -378,6 +381,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FF5D13AF2A86C2D800BC9BD6 /* Preview Assets.xcassets in Resources */,
+				07367C462ACA021F00A558ED /* Basic-Car-Maintenance.xcconfig in Resources */,
 				FFC8CDA42AA385E800D129A6 /* GoogleService-Info.plist in Resources */,
 				FF5D13AB2A86C2D800BC9BD6 /* Assets.xcassets in Resources */,
 				FF755B432A90915E00F49A13 /* Localizable.xcstrings in Resources */,

--- a/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct AddVehicleView: View {
-    
     let addTapped: (Vehicle) -> Void
     
     @State private var name = ""
@@ -42,7 +41,11 @@ struct AddVehicleView: View {
                 ToolbarItem {
                     Button {
                         let vehicle = Vehicle(name: name, make: make, model: model)
-                        addTapped(vehicle)
+                        
+                        if !name.isEmpty && !make.isEmpty && !model.isEmpty {
+                            addTapped(vehicle)
+                        }
+                        
                         dismiss()
                     } label: {
                         Text("Add")
@@ -54,5 +57,5 @@ struct AddVehicleView: View {
 }
 
 #Preview {
-    AddVehicleView() { _ in }
+    AddVehicleView { _ in }
 }

--- a/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
@@ -13,6 +13,9 @@ struct AddVehicleView: View {
     @State private var name = ""
     @State private var make = ""
     @State private var model = ""
+    private var isVehicleValid: Bool {
+        !name.isEmpty && !make.isEmpty && !model.isEmpty
+    }
     
     @Environment(\.dismiss) var dismiss
     
@@ -41,15 +44,12 @@ struct AddVehicleView: View {
                 ToolbarItem {
                     Button {
                         let vehicle = Vehicle(name: name, make: make, model: model)
-                        
-                        if !name.isEmpty && !make.isEmpty && !model.isEmpty {
-                            addTapped(vehicle)
-                        }
-                        
-                        dismiss()
+                        addTapped(vehicle)
+                        dismiss()                        
                     } label: {
                         Text("Add")
                     }
+                    .disabled(!isVehicleValid)
                 }
             }
         }


### PR DESCRIPTION
Now, to add a vehicle, its name make, and model must have at least one character.

# What it Does
* Closes issue #24 
* It checks for the name, make, and model of a vehicle before adding it.

# How I Tested
* Add a list of steps to show the functionality of your feature
For example:
* Run the application
* Tap the 'Settings' button
* Tap on 'Add Vehicle' Button
* Do not fill any details and tap 'Add'.
* Vehicle will not be added .
* Now tap on  'Add Vehicle' Button again.
* This time, fill some details.
* Tap on 'Add Button'
* Vehicle will get added.

# Notes
* Added check for name, make, and model strings, whether they are empty or not.