### PR TITLE
Added error handling for deleting vehicles

### DIFF
--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -28,13 +28,13 @@
     "Delete" : {
 
     },
-    "Failed to add vehicle. Unknown error." : {
+    "Failed To Add Vehicle. Unknown Error." : {
 
     },
-    "Failed to delete vehicle" : {
+    "Failed To Delete Vehicle" : {
 
     },
-    "Failed to delete vehicle\nDetails:%@" : {
+    "Failed To Delete Vehicle\nDetails:%@" : {
 
     },
     "GitHub Repo" : {
@@ -55,7 +55,7 @@
     "Notes" : {
 
     },
-    "Ok, got it!" : {
+    "OK" : {
 
     },
     "Profile" : {

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -25,6 +25,18 @@
     "Date" : {
 
     },
+    "Delete" : {
+
+    },
+    "Failed to add vehicle. Unknown error." : {
+
+    },
+    "Failed to delete vehicle" : {
+
+    },
+    "Failed to delete vehicle\nDetails:%@" : {
+
+    },
     "GitHub Repo" : {
 
     },
@@ -41,6 +53,9 @@
 
     },
     "Notes" : {
+
+    },
+    "Ok, got it!" : {
 
     },
     "Profile" : {

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -56,9 +56,9 @@ final class SettingsViewModel: ObservableObject {
         }
     }
     
-    func deleteVehicle(_ vehicle: Vehicle, then: @escaping(Result<String, Error>) -> Void) async {
+    func deleteVehicle(_ vehicle: Vehicle) async throws {
       guard let documentId = vehicle.id else {
-          fatalError("Event \(vehicle.name) has no document ID.")
+        fatalError("Event \(vehicle.name) has no document ID.")
       }
 
       do {
@@ -69,9 +69,8 @@ final class SettingsViewModel: ObservableObject {
           .delete()
 
         vehicles.removeAll { $0.id == vehicle.id }
-        then(.success("Vehicle deleted"))
       } catch {
-        then(.failure(error))
+        throw error
       }
     }
 }

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -56,14 +56,22 @@ final class SettingsViewModel: ObservableObject {
         }
     }
     
-    func deleteVehicle(_ vehicle: Vehicle) async {
-        guard let documentId = vehicle.id else {
-            fatalError("Event \(vehicle.name) has no document ID.")
-        }
-        try? await Firestore
-            .firestore()
-            .collection("vehicles")
-            .document(documentId)
-            .delete()
+    func deleteVehicle(_ vehicle: Vehicle, then: @escaping(Result<String, Error>) -> Void) async {
+      guard let documentId = vehicle.id else {
+          fatalError("Event \(vehicle.name) has no document ID.")
+      }
+
+      do {
+        try await Firestore
+          .firestore()
+          .collection("vehicles")
+          .document(documentId)
+          .delete()
+
+        vehicles.removeAll { $0.id == vehicle.id }
+        then(.success("Vehicle deleted"))
+      } catch {
+        then(.failure(error))
+      }
     }
 }

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -108,15 +108,15 @@ struct SettingsView: View {
                 
                 Text("Version \(Bundle.main.versionNumber) (\(Bundle.main.buildNumber))")
             }
-            .alert("Failed to delete vehicle", isPresented: $showDeleteVehicleError, actions: {
-                Button("Ok, got it!") {
+            .alert("Failed To Delete Vehicle", isPresented: $showDeleteVehicleError, actions: {
+                Button("OK") {
                   showDeleteVehicleError = false
                 }
             }, message: {
                 if let errorDetails {
-                    Text("Failed to delete vehicle\nDetails:\(errorDetails.localizedDescription)")
+                    Text("Failed To Delete Vehicle\nDetails:\(errorDetails.localizedDescription)")
                 } else {
-                    Text("Failed to add vehicle. Unknown error.")
+                    Text("Failed To Add Vehicle. Unknown Error.")
                 }
             })
             .navigationTitle(Text("Settings"))

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -70,14 +70,11 @@ struct SettingsView: View {
                         .swipeActions {
                             Button("Delete") {
                               Task {
-                                await viewModel.deleteVehicle(vehicle) { result in
-                                  switch result {
-                                  case .success:
-                                      isShowingAddVehicle = false
-                                  case .failure(let error):
-                                      errorDetails = error
-                                      showDeleteVehicleError = true
-                                  }
+                                do {
+                                  try await viewModel.deleteVehicle(vehicle)
+                                } catch {
+                                  errorDetails = error
+                                  showDeleteVehicleError = true
                                 }
                               }
                             }


### PR DESCRIPTION
# What it Does
* Closes issue #12 
* Adds swipe actions for vehicles to delete them
* Adds error handling and an alert for deleting vehicles

# How I Tested
* Add a vehicle
* Swipe left and tap on Delete
* Add this line to `deleteVehicle` imitate an error: `then(.failure(URLError(URLError.Code.badURL)))`
* When deleting, the app shows an alert

# Notes
* Made the implementation similar to https://github.com/mikaelacaron/Basic-Car-Maintenance/pull/25 to have consistency in the code
* In the PR above `await` needs to be added before adding a vehicle to the Firebase, otherwise it displays a vehicle on the screen and when trying to delete it right after creation, the app shuts down

# Screenshot

<img src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/66741910/49407640-4b5b-4f6f-a052-4787c6140328" width="250"  />
<img src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/66741910/4503eeb4-5005-4209-b475-cc09b611b1dc" width="250"  />