### PR TITLE
Fixed the bug which was causing vehicle with no details to be added.

### DIFF
--- a/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
@@ -14,6 +14,9 @@ struct AddVehicleView: View {
     @State private var name = ""
     @State private var make = ""
     @State private var model = ""
+    private var isVehicleValid: Bool {
+        !name.isEmpty && !make.isEmpty && !model.isEmpty
+    }
     
     @Environment(\.dismiss) var dismiss
     
@@ -47,6 +50,7 @@ struct AddVehicleView: View {
                     } label: {
                         Text("Add")
                     }
+                    .disabled(!isVehicleValid)
                 }
             }
         }


### PR DESCRIPTION
Added a check to ensure that a vehicle can only be added if it has at least one character in each of its name, model, and make fields.

# What it Does
* Closes issue #24 
* It checks for the name, make, and model of a vehicle before adding it.

# How I Tested
* Run the application
* Tap the 'Settings' button
* Tap on 'Add Vehicle' Button
* Do not fill any details and tap 'Add'.
* 'Add Button' will be grayed out until you fill some details in all the columns.
* Fill some details.
* Tap on 'Add Button'.
* Vehicle will get added.

# Notes
* Added check for name, make, and model strings, whether they are empty or not.
* Please close pull request #26, I am creating this pull request after making all the necessary and suggested changes.

# Screens

https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/63922782/b3729fdc-cd09-4b21-b86b-faab9ba39656