### PR TITLE
Adds Bar Button Item to Order Events by Date

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -11,10 +11,18 @@ import Foundation
 
 @MainActor
 class DashboardViewModel: ObservableObject {
-    
     let authenticationViewModel: AuthenticationViewModel
     
     @Published var events = [MaintenanceEvent]()
+    @Published var sortOption: SortOption = .custom
+    
+    var sortedEvents: [MaintenanceEvent] {
+        switch sortOption {
+        case .oldestToNewest: events.sorted(by: {$0.date < $1.date })
+        case .newestToOldest: events.sorted(by: { $0.date > $1.date })
+        case .custom: events
+        }
+    }
     
     init(authenticationViewModel: AuthenticationViewModel) {
         self.authenticationViewModel = authenticationViewModel
@@ -64,5 +72,26 @@ class DashboardViewModel: ObservableObject {
             .collection("maintenance_events")
             .document(documentId)
             .delete()
+    }
+}
+
+// MARK: - Sort Option
+extension DashboardViewModel {
+    enum SortOption: Int, CaseIterable, Identifiable {
+        case oldestToNewest = 0
+        case newestToOldest = 1
+        case custom = 2
+        
+        var id: Int {
+            rawValue
+        }
+        
+        var label: String {
+            switch self {
+            case .oldestToNewest: "Oldest to Newest"
+            case .newestToOldest: "Newest to Oldest"
+            case .custom: "Custom"
+            }
+        }
     }
 }

--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -18,8 +18,8 @@ class DashboardViewModel: ObservableObject {
     
     var sortedEvents: [MaintenanceEvent] {
         switch sortOption {
-        case .oldestToNewest: events.sorted(by: {$0.date < $1.date })
-        case .newestToOldest: events.sorted(by: { $0.date > $1.date })
+        case .oldestToNewest: events.sorted {$0.date < $1.date }
+        case .newestToOldest: events.sorted { $0.date > $1.date }
         case .custom: events
         }
     }
@@ -86,7 +86,7 @@ extension DashboardViewModel {
             rawValue
         }
         
-        var label: String {
+        var label: LocalizedStringResource {
             switch self {
             case .oldestToNewest: "Oldest to Newest"
             case .newestToOldest: "Newest to Oldest"

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -40,7 +40,7 @@ struct DashboardView: View {
                 }
                 .listStyle(.inset)
             }
-            .animation(.linear, value: viewModel.sortedEvents)
+            .animation(.linear, value: viewModel.sortOption)
             .navigationTitle(Text("Dashboard"))
             .sheet(isPresented: $isShowingAddView) {
                 AddMaintenanceView() { event in

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct DashboardView: View {
     @State private var isShowingAddView = false
-    
     @StateObject private var viewModel: DashboardViewModel
     
     init(authenticationViewModel: AuthenticationViewModel) {
@@ -19,7 +18,7 @@ struct DashboardView: View {
     var body: some View {
         NavigationStack {
             List {
-                ForEach(viewModel.events) { event in
+                ForEach(viewModel.sortedEvents) { event in
                     VStack(alignment: .leading, spacing: 8) {
                         Text(event.title)
                             .font(.title3)
@@ -41,6 +40,7 @@ struct DashboardView: View {
                 }
                 .listStyle(.inset)
             }
+            .animation(.linear, value: viewModel.sortedEvents)
             .navigationTitle(Text("Dashboard"))
             .sheet(isPresented: $isShowingAddView) {
                 AddMaintenanceView() { event in
@@ -51,11 +51,22 @@ struct DashboardView: View {
                 }
             }
             .toolbar {
-                ToolbarItem(placement: .primaryAction) {
+                ToolbarItemGroup(placement: .primaryAction) {
                     Button {
                         isShowingAddView.toggle()
                     } label: {
                         Image(systemName: "plus")
+                    }
+                    
+                    Menu {
+                        Picker(selection: $viewModel.sortOption, content: {
+                            ForEach(DashboardViewModel.SortOption.allCases, id: \.self) { option in
+                                Text(option.label)
+                                    .tag(option.id)
+                            }
+                        }, label: { EmptyView() })
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
                     }
                 }
             }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -65,9 +65,9 @@ struct DashboardView: View {
                     
                     Menu {
                         Picker(selection: $viewModel.sortOption, content: {
-                            ForEach(DashboardViewModel.SortOption.allCases, id: \.self) { option in
+                            ForEach(DashboardViewModel.SortOption.allCases) { option in
                                 Text(option.label)
-                                    .tag(option.id)
+                                    .tag(option)
                             }
                         }, label: { EmptyView() })
                     } label: {

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -71,7 +71,7 @@ struct DashboardView: View {
                             }
                         }, label: { EmptyView() })
                     } label: {
-                        Image(systemName: "ellipsis.circle")
+                        Image(systemName: "line.3.horizontal.decrease.circle")
                     }
                 }
             }

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -22,6 +22,9 @@
     "Additional Notes" : {
 
     },
+    "Custom" : {
+
+    },
     "Dashboard" : {
 
     },
@@ -43,7 +46,13 @@
     "Name" : {
 
     },
+    "Newest to Oldest" : {
+
+    },
     "Notes" : {
+
+    },
+    "Oldest to Newest" : {
 
     },
     "Profile" : {


### PR DESCRIPTION
# What it Does
* Closes issue #8 
* Adds a ellipses button in the toolbar to allow users to sort by: 
    * Newest to Oldest
    * Oldest to Newest
    * Custom (however firebase orders them)

# How I Tested
* Added two events in the simulator
* Tapped on the ellipses button in the toolbar
* Toggled between the three options 

# Notes
* Also added a linear animation to the list so that the user can visually see the items reordering themselves

# Screenshot


https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/3428339/22efce5f-ddcf-4ff9-9802-242d73f12c98

