### PR TITLE
Update new event with document ID returned from Firebase 

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -24,16 +24,20 @@ class DashboardViewModel: ObservableObject {
         if let uid = authenticationViewModel.user?.uid {
             var eventToAdd = maintenanceEvent
             eventToAdd.userID = uid
-            
-            try? Firestore
+
+            let eventAdded = try? Firestore
                 .firestore()
                 .collection("maintenance_events")
                 .addDocument(from: eventToAdd)
+
+            var event = maintenanceEvent
+            if let documentId = eventAdded?.documentID {
+                event.id = documentId
+            }
+            events.append(event)
         }
-        
-        events.append(maintenanceEvent)
     }
-    
+
     func getMaintenanceEvents() async {
         if let uid = authenticationViewModel.user?.uid {
             let db = Firestore.firestore()


### PR DESCRIPTION
# What it Does
* Closes #47 
* Fixed the crash which happened due to missing id.

# How I Tested
* Create a new maintenance event.
* Delete immediately when you create the event.
* Now, its getting deleted. Issue is fixed.

# Notes
* Inserting the id before I append the event into array.

# Screenshot

https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/54598657/164d01e9-cc20-4b92-a5a3-783fb2f5df68


