### PR TITLE
GitHub Actions to build and deploy docc documentations

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -7,6 +7,9 @@ permissions:
   contents: read
   pages: write
   id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -16,6 +16,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.0.0"
       - name: Run Build Docs
         run: ./build-docc.sh
       - name: Setup Pages

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -1,0 +1,37 @@
+name: Deploy Documentation
+on:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run Build Docs
+        run: ./build-docc.sh
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .docs
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -19,6 +19,9 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "15.0.0"
+      - name: Setup Config file
+        run: |
+          cp Basic-Car-Maintenance.xcconfig.template Basic-Car-Maintenance.xcconfig
       - name: Run Build Docs
         run: ./build-docc.sh
       - name: Setup Pages

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,7 +21,8 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
   - Source/ExcludedFolder
   - Source/ExcludedFile.swift
-  - Source/*/ExcludedFile.swift # Exclude files with a wildcard
+  - Source/*/ExcludedFile.swift
+  - .derivedData # Exclude files with a wildcard
 analyzer_rules: # Rules run by `swiftlint analyze` (experimental)
   - explicit_self
 

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -914,7 +914,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.icyappstudio.app.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -885,7 +885,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.icyappstudio.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -914,7 +914,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.icyappstudio.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -885,7 +885,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.icyappstudio.app.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.icyappstudio.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -885,7 +885,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.icyappstudio.app.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -914,7 +914,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.icyappstudio.app.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.icyappstudio.Basic-Car-Maintenance.Basic-Car-Maintenance-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/build-docc.sh
+++ b/build-docc.sh
@@ -8,7 +8,7 @@ xcrun xcodebuild docbuild \
 xcrun docc process-archive transform-for-static-hosting \
     "$PWD/.derivedData/Build/Products/Debug-iphonesimulator/Basic-Car-Maintenance.doccarchive" \
     --output-path ".docs" \
-    --hosting-base-path "https://mikaelacaron.github.io/Basic-Car-Maintenance"
+    --hosting-base-path ""
 
 echo '<script>window.location.href += "/documentation/Basic_Car_Maintenance"</script>' > .docs/index.html
 

--- a/build-docc.sh
+++ b/build-docc.sh
@@ -1,0 +1,15 @@
+##!/bin/sh
+
+xcrun xcodebuild docbuild \
+    -scheme Basic-Car-Maintenance \
+    -destination 'generic/platform=iOS Simulator' \
+    -derivedDataPath "$PWD/.derivedData"
+
+xcrun docc process-archive transform-for-static-hosting \
+    "$PWD/.derivedData/Build/Products/Debug-iphonesimulator/Basic-Car-Maintenance.doccarchive" \
+    --output-path ".docs" \
+    --hosting-base-path "https://mikaelacaron.github.io/Basic-Car-Maintenance"
+
+echo '<script>window.location.href += "/documentation/Basic_Car_Maintenance"</script>' > .docs/index.html
+
+

--- a/build-docc.sh
+++ b/build-docc.sh
@@ -8,7 +8,7 @@ xcrun xcodebuild docbuild \
 xcrun docc process-archive transform-for-static-hosting \
     "$PWD/.derivedData/Build/Products/Debug-iphonesimulator/Basic-Car-Maintenance.doccarchive" \
     --output-path ".docs" \
-    --hosting-base-path /
+    --hosting-base-path "Basic-Car-Maintenance"
 
 echo '<script>window.location.href += "documentation/basic_car_maintenance"</script>' > .docs/index.html
 

--- a/build-docc.sh
+++ b/build-docc.sh
@@ -8,7 +8,7 @@ xcrun xcodebuild docbuild \
 xcrun docc process-archive transform-for-static-hosting \
     "$PWD/.derivedData/Build/Products/Debug-iphonesimulator/Basic-Car-Maintenance.doccarchive" \
     --output-path ".docs" \
-    --hosting-base-path ""
+    --hosting-base-path "https://rizwan.dev/Basic-Car-Maintenance/"
 
 echo '<script>window.location.href += "documentation/basic_car_maintenance"</script>' > .docs/index.html
 

--- a/build-docc.sh
+++ b/build-docc.sh
@@ -10,6 +10,6 @@ xcrun docc process-archive transform-for-static-hosting \
     --output-path ".docs" \
     --hosting-base-path ""
 
-echo '<script>window.location.href += "/documentation/Basic_Car_Maintenance"</script>' > .docs/index.html
+echo '<script>window.location.href += "documentation/basic_car_maintenance"</script>' > .docs/index.html
 
 

--- a/build-docc.sh
+++ b/build-docc.sh
@@ -8,7 +8,7 @@ xcrun xcodebuild docbuild \
 xcrun docc process-archive transform-for-static-hosting \
     "$PWD/.derivedData/Build/Products/Debug-iphonesimulator/Basic-Car-Maintenance.doccarchive" \
     --output-path ".docs" \
-    --hosting-base-path "https://rizwan.dev/Basic-Car-Maintenance/"
+    --hosting-base-path /
 
 echo '<script>window.location.href += "documentation/basic_car_maintenance"</script>' > .docs/index.html
 


### PR DESCRIPTION
# What it Does
* Closes #55 
* Adds new script for building documentation and preparing docs folder with html files
* Adds new GitHub action for deploying the docc to GitHub Pages

# How I Tested
* I have created the same steps on my fork and made GitHub page deployment

# Notes
* Please take a look at the documentation hosted in my fork - [link](https://rizwan.dev/Basic-Car-Maintenance) for example 
* To make it work for this repo . all we have to do is enable GitHub Actions on Pages settings. like below 

![image](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/12063704/ed544e68-1329-4f8f-a7c3-d22dde9e9264)
