### PR TITLE
FEATURE - Home Screen Quick Actions

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		023057F22ACFAD79006C5A73 /* EditEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */; };
 		898009792AD1899700604E7C /* ContributorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898009782AD1899700604E7C /* ContributorTests.swift */; };
+		8AEE816F2ACF37F800FC0C2A /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE816E2ACF37F800FC0C2A /* Action.swift */; };
+		8AEE81722ACF384D00FC0C2A /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE81712ACF384D00FC0C2A /* MainTabView.swift */; };
 		E58499662ACDDA8B00634660 /* ContributorsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58499652ACDDA8B00634660 /* ContributorsListView.swift */; };
 		E58499682ACDDA9A00634660 /* ContributorsProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58499672ACDDA9A00634660 /* ContributorsProfileView.swift */; };
 		E584996A2ACDDAFF00634660 /* Contributor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58499692ACDDAFF00634660 /* Contributor.swift */; };
@@ -86,6 +88,9 @@
 /* Begin PBXFileReference section */
 		023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEventDetailView.swift; sourceTree = "<group>"; };
 		898009782AD1899700604E7C /* ContributorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorTests.swift; sourceTree = "<group>"; };
+		8AEE816E2ACF37F800FC0C2A /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
+		8AEE81712ACF384D00FC0C2A /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		8AEE81732ACF394E00FC0C2A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E58499652ACDDA8B00634660 /* ContributorsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorsListView.swift; sourceTree = "<group>"; };
 		E58499672ACDDA9A00634660 /* ContributorsProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorsProfileView.swift; sourceTree = "<group>"; };
 		E58499692ACDDAFF00634660 /* Contributor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contributor.swift; sourceTree = "<group>"; };
@@ -285,7 +290,9 @@
 			children = (
 				FF755B422A90915E00F49A13 /* Localizable.xcstrings */,
 				FFC8CDA32AA385E800D129A6 /* GoogleService-Info.plist */,
+				8AEE81732ACF394E00FC0C2A /* Info.plist */,
 				FF5D13A62A86C2D600BC9BD6 /* BasicCarMaintenanceApp.swift */,
+				8AEE81712ACF384D00FC0C2A /* MainTabView.swift */,
 				FFBFE08F2A98EFDD000A9BEB /* Models */,
 				FF755B3F2A908EC400F49A13 /* Dashboard */,
 				FF755B402A908EC900F49A13 /* Settings */,
@@ -319,6 +326,7 @@
 				FFBFE0902A98EFEC000A9BEB /* MaintenanceEvent.swift */,
 				E58499692ACDDAFF00634660 /* Contributor.swift */,
 				FFBFE0922A98F212000A9BEB /* Vehicle.swift */,
+				8AEE816E2ACF37F800FC0C2A /* Action.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -571,10 +579,12 @@
 				023057F22ACFAD79006C5A73 /* EditEventDetailView.swift in Sources */,
 				FF755B3E2A908E7A00F49A13 /* SettingsView.swift in Sources */,
 				FF3DDF522AA4D28F009D91C4 /* DashboardViewModel.swift in Sources */,
+				8AEE816F2ACF37F800FC0C2A /* Action.swift in Sources */,
 				FFBFE0972A98F7CB000A9BEB /* AddVehicleView.swift in Sources */,
 				E584996A2ACDDAFF00634660 /* Contributor.swift in Sources */,
 				FFC67D1D2AAEF7920073B338 /* SettingsViewModel.swift in Sources */,
 				FF755B3C2A908E3E00F49A13 /* DashboardView.swift in Sources */,
+				8AEE81722ACF384D00FC0C2A /* MainTabView.swift in Sources */,
 				E58499662ACDDA8B00634660 /* ContributorsListView.swift in Sources */,
 				FFBFE0932A98F212000A9BEB /* Vehicle.swift in Sources */,
 				FF5D13A72A86C2D600BC9BD6 /* BasicCarMaintenanceApp.swift in Sources */,
@@ -759,6 +769,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Basic-Car-Maintenance/Shared/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Basic Car";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -797,6 +808,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Basic-Car-Maintenance/Shared/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Basic Car";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;

--- a/Basic-Car-Maintenance/Shared/BasicCarMaintenanceApp.swift
+++ b/Basic-Car-Maintenance/Shared/BasicCarMaintenanceApp.swift
@@ -10,13 +10,13 @@ import SwiftUI
 
 @main
 struct BasicCarMaintenanceApp: App {
-    private let actionService = ActionService.shared
+    @State private var actionService = ActionService.shared
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     var body: some Scene {
         WindowGroup {
             MainTabView()
-                .environmentObject(actionService)
+                .environment(actionService)
         }
     }
 }
@@ -25,7 +25,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     private let actionService = ActionService.shared
     
     func application(
-        _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         FirebaseApp.configure()
         return true

--- a/Basic-Car-Maintenance/Shared/BasicCarMaintenanceApp.swift
+++ b/Basic-Car-Maintenance/Shared/BasicCarMaintenanceApp.swift
@@ -10,26 +10,68 @@ import SwiftUI
 
 @main
 struct BasicCarMaintenanceApp: App {
-    @State private var authenticationViewModel: AuthenticationViewModel
-    
-    init() {
-        FirebaseApp.configure()
-        _authenticationViewModel = .init(initialValue: AuthenticationViewModel())
-    }
+    private let actionService = ActionService.shared
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     var body: some Scene {
         WindowGroup {
-            TabView {
-                DashboardView(authenticationViewModel: authenticationViewModel)
-                    .tabItem {
-                        Label("Dashboard", systemImage: "list.dash.header.rectangle")
-                    }
-                
-                SettingsView(authenticationViewModel: authenticationViewModel)
-                    .tabItem {
-                        Label("Settings", systemImage: "gear")
-                    }
-            }
+            MainTabView()
+                .environmentObject(actionService)
         }
+    }
+}
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    private let actionService = ActionService.shared
+    
+    func application(
+        _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        FirebaseApp.configure()
+        return true
+    }
+    
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        // get the shortcut when the app is launching
+        if let shortcutItem = options.shortcutItem,
+           let action = Action(shortcutItem: shortcutItem) {
+            actionService.updateIncoming(action)
+        }
+        
+        let configuration = UISceneConfiguration(
+            name: connectingSceneSession.configuration.name,
+            sessionRole: connectingSceneSession.role
+        )
+        configuration.delegateClass = SceneDelegate.self
+        return configuration
+    }
+}
+
+class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    private let actionService = ActionService.shared
+    
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        // get the shortcut if the app is already running
+        let action = Action(shortcutItem: shortcutItem)
+        actionService.updateIncoming(action)
+        completionHandler(true)
+    }
+}
+
+@Observable
+class ActionService: ObservableObject {
+    static let shared = ActionService()
+    private(set) var action: Action?
+    
+    fileprivate func updateIncoming(_ action: Action?) {
+        self.action = action
     }
 }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/AddMaintenanceView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/AddMaintenanceView.swift
@@ -14,6 +14,7 @@ struct AddMaintenanceView: View {
     @State private var title = ""
     @State private var date = Date()
     @State private var notes = ""
+    @Environment(\.dismiss) var dismiss
     
     var body: some View {
         NavigationStack {
@@ -42,6 +43,7 @@ struct AddMaintenanceView: View {
                     Button {
                         let event = MaintenanceEvent(title: title, date: date, notes: notes)
                         addTapped(event)
+                        dismiss()
                     } label: {
                         Text("Add")
                     }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct DashboardView: View {
-    @EnvironmentObject var actionService: ActionService
+    @Environment(ActionService.self) var actionService
     @Environment(\.scenePhase) var scenePhase
     @State private var isShowingAddView = false
     @Bindable private var viewModel: DashboardViewModel

--- a/Basic-Car-Maintenance/Shared/Info.plist
+++ b/Basic-Car-Maintenance/Shared/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>wrench.and.screwdriver.fill</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>New Maintenence</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>NewMaintenance</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>plus.circle.fill</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Add Vehicle</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>AddVehicle</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Basic-Car-Maintenance/Shared/MainTabView.swift
+++ b/Basic-Car-Maintenance/Shared/MainTabView.swift
@@ -1,0 +1,55 @@
+//
+//  MainTabView.swift
+//  Basic-Car-Maintenance
+//
+//  Created by Omar Hegazy on 05/10/2023.
+//
+
+import SwiftUI
+
+enum TabSelection: Int {
+    case dashboard = 0
+    case settings = 1
+}
+
+struct MainTabView: View {
+    @EnvironmentObject var actionService: ActionService
+    @Environment(\.scenePhase) var scenePhase
+    @State var authenticationViewModel = AuthenticationViewModel()
+    @State var selectedTab: TabSelection = .dashboard
+    
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            DashboardView(authenticationViewModel: authenticationViewModel)
+                .tag(TabSelection.dashboard)
+                .tabItem {
+                    Label("Dashboard", systemImage: "list.dash.header.rectangle")
+                }
+            
+            SettingsView(authenticationViewModel: authenticationViewModel)
+                .tag(TabSelection.settings)
+                .tabItem {
+                    Label("Settings", systemImage: "gear")
+                }
+        }
+        .onChange(of: scenePhase) { _, newScenePhase in
+            guard
+                case .active = newScenePhase,
+                let action = actionService.action
+            else { return }
+            
+            // select the tab where the desired view is located to make sure
+            // it is presented from the proper hierarchy.
+            switch action {
+            case .newMaintenance:
+                selectedTab = .dashboard
+            case .addVehicle:
+                selectedTab = .settings
+            }
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+}

--- a/Basic-Car-Maintenance/Shared/MainTabView.swift
+++ b/Basic-Car-Maintenance/Shared/MainTabView.swift
@@ -12,8 +12,9 @@ enum TabSelection: Int {
     case settings = 1
 }
 
+@MainActor
 struct MainTabView: View {
-    @EnvironmentObject var actionService: ActionService
+    @Environment(ActionService.self) var actionService
     @Environment(\.scenePhase) var scenePhase
     @State var authenticationViewModel = AuthenticationViewModel()
     @State var selectedTab: TabSelection = .dashboard

--- a/Basic-Car-Maintenance/Shared/Models/Action.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Action.swift
@@ -1,0 +1,31 @@
+//
+//  Action.swift
+//  Basic-Car-Maintenance
+//
+//  Created by Omar Hegazy on 05/10/2023.
+//
+
+import UIKit
+
+enum ActionType: String {
+    case newMaintenance = "NewMaintenance"
+    case addVehicle = "AddVehicle"
+}
+
+enum Action: Equatable {
+    case newMaintenance
+    case addVehicle
+    
+    init?(shortcutItem: UIApplicationShortcutItem) {
+        guard let type = ActionType(rawValue: shortcutItem.type) else {
+            return nil
+        }
+        
+        switch type {
+        case .newMaintenance:
+            self = .newMaintenance
+        case .addVehicle:
+            self = .addVehicle
+        }
+    }
+}

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -11,10 +11,13 @@ struct SettingsView: View {
     @State private var viewModel: SettingsViewModel
     @State private var isShowingAddVehicle = false
     @State private var showDeleteVehicleError = false
+    @EnvironmentObject var actionService: ActionService
+    @Environment(\.scenePhase) var scenePhase
     @State var errorDetails: Error?
     
     init(authenticationViewModel: AuthenticationViewModel) {
-        viewModel = SettingsViewModel(authenticationViewModel: authenticationViewModel)
+        let settingsViewModel = SettingsViewModel(authenticationViewModel: authenticationViewModel)
+        _viewModel = .init(initialValue: settingsViewModel)
     }
     
     var body: some View {
@@ -131,6 +134,26 @@ struct SettingsView: View {
                         await viewModel.addVehicle(vehicle)
                     }
                 }
+            }
+        }
+        .onChange(of: scenePhase) { _, newScenePhase in
+            guard case .active = newScenePhase else { return }
+            
+            guard let action = actionService.action,
+                  action == .addVehicle
+            else {
+                // another action has been triggered
+                // so we will need to dismiss the current presented view
+                isShowingAddVehicle = false
+                return
+            }
+            
+            // if the view is already presented, do nothing
+            guard !isShowingAddVehicle else { return }
+            // delay the presentation of the view a bit
+            // to make sure the already presented view is dismissed.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                isShowingAddVehicle = true
             }
         }
     }

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -11,9 +11,9 @@ struct SettingsView: View {
     @State private var viewModel: SettingsViewModel
     @State private var isShowingAddVehicle = false
     @State private var showDeleteVehicleError = false
-    @EnvironmentObject var actionService: ActionService
+    @Environment(ActionService.self) var actionService
     @Environment(\.scenePhase) var scenePhase
-    @State var errorDetails: Error?
+    @State private var errorDetails: Error?
     
     init(authenticationViewModel: AuthenticationViewModel) {
         let settingsViewModel = SettingsViewModel(authenticationViewModel: authenticationViewModel)


### PR DESCRIPTION
# What it Does
Implementing Home Screen quick actions for Add maintenance in [issue-65](https://github.com/mikaelacaron/Basic-Car-Maintenance/issues/65) as well as Add new vehicle
* Closes #65
## Implementing Home quick actions using the following flow:
1. Receive the shortcutItem when the is being launched or when the app is already running in background
2. Publish the new value using the singleton `ActionService` class by injecting it as an EnvironmentObject to all views
3. The `MainTabView` will be responsible for selecting the corresponding tab to make sure the view is presented from the relevant hierarchy
4. Any child view will that has a service will be responsible for dismissing its presented view (if it's not the desired one) and to show it if it is (To prevent presenting a view while another view is already presented)

# How I Tested
### Scenario 1:
1. Open the App
2. move it to background
3. long press on the app icon
4. select "**Add Maintenance**"
5. The "**Add Maintenance**"  screen should be opened once the app is moved to foreground

### Scenario 2:
1. Open the App
2. Move it to background
3. Long press on the app icon
4. Select "**Add Vehicle**"
5. The "**Add Vehicle**"  screen should be opened  once the app is moved to foreground

### Scenario 3:
1. Open the App
2. Move it to background
3. Long press on the app icon
4. Select "**Add Maintenance**"
5. When the opens and "**Add Maintenance**" screen appears, move the app to background again
6. Long press on the app icon
7. Select "**Add Vehicle**"
8. The "**Add Maintenance**" screen  should be dismissed and the "**Add Vehicle**"  screen should be opened

### Scenario 4:
1. Open the App
2. Move it to background
3. Long press on the app icon
4. Select "**Add Vehicle**"
5. When the opens and "**Add Vehicle**" screen appears, move the app to background again
6. Long press on the app icon
7. Select "**Add Maintenance**"
8. The "**Add Vehicle**" screen should be dismissed and the "**Add Maintenance**" screen should be opened

### Scenario 5:
1. When the app is terminated, long press on the app icon
2. Select "**Add Maintenance**" or "**Add Vehicle**"
3. The selected service should appear once the app is opened

# Notes
* Anything else that should be noted about how you implemented this feature?

# Screenshot
* Add a screenshot of your new feature! OR show a screen recording of it in action. (On the simulator press Cmd + R to record, and the stop button when done). **This video should be no longer than 30 seconds.**