### PR TITLE
Removing Disabled Swift Lint rules 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,5 @@
 # By default, SwiftLint uses a set of sensible default rules you can adjust:
 disabled_rules: # rule identifiers turned on by default to exclude from running
-  - colon
-  - comma
   - control_statement
   - type_name
   - trailing_whitespace

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,5 @@
 # By default, SwiftLint uses a set of sensible default rules you can adjust:
 disabled_rules: # rule identifiers turned on by default to exclude from running
-  - control_statement
-  - type_name
   - trailing_whitespace
   - identifier_name
   - empty_parentheses_with_trailing_closure

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,6 @@
 # By default, SwiftLint uses a set of sensible default rules you can adjust:
 disabled_rules: # rule identifiers turned on by default to exclude from running
   - trailing_whitespace
-  - identifier_name
   - empty_parentheses_with_trailing_closure
 opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_count # Find all the available rules by running: `swiftlint rules`
@@ -17,7 +16,6 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
   - Source/ExcludedFolder
   - Source/ExcludedFile.swift
-  - Source/*/ExcludedFile.swift
   - .derivedData # Exclude files with a wildcard
 analyzer_rules: # Rules run by `swiftlint analyze` (experimental)
   - explicit_self
@@ -28,6 +26,11 @@ force_cast: warning # implicitly
 force_try:
   severity: warning # explicitly
 # rules that have both warning and error levels, can set just the warning level
+identifier_name:
+  excluded:
+    - id
+    - db
+    - URL
 # implicitly
 line_length: 110
 # they can set both implicitly with an array

--- a/Basic-Car-Maintenance-Widget/BasicCarMaintenanceWidget.swift
+++ b/Basic-Car-Maintenance-Widget/BasicCarMaintenanceWidget.swift
@@ -38,7 +38,7 @@ struct SimpleEntry: TimelineEntry {
     let configuration: ConfigurationAppIntent
 }
 
-struct BasicCarMaintenanceWidgetEntryView : View {
+struct BasicCarMaintenanceWidgetEntryView: View {
     var entry: Provider.Entry
 
     var body: some View {

--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -18,7 +18,7 @@ class DashboardViewModel {
     var showAddErrorAlert = false
     var showErrorAlert = false
     var isShowingAddMaintenanceEvent = false
-    var errorMessage : String = ""
+    var errorMessage: String = ""
     var sortOption: SortOption = .custom
     
     var sortedEvents: [MaintenanceEvent] {

--- a/Basic-Car-Maintenance/Shared/Models/Contributor.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Contributor.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Contributor: Codable, Hashable , Identifiable {
+struct Contributor: Codable, Hashable, Identifiable {
     let login: String
     let id: Int
     let nodeID: String

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ContributorsListView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ContributorsListView.swift
@@ -22,8 +22,7 @@ struct ContributorsListView: View {
                         }
                 }
             } else {
-                ProgressView() {
-                }
+                ProgressView()
             }
         }
         .task {


### PR DESCRIPTION
# What it Does
* Closes #72
* Removes almost all of the SwiftLint disabled rules

# How I Tested
* Project builds

# Notes
* I didn't take out `trailing_whitespace` because I don't have this set in my Xcode, and it's a specific setting all contributors would have to enable, which can be difficult for people to follow
* I left this rule `empty_parentheses_with_trailing_closure`, because I think views with closures look like Views when it's defined this way

```swift
AddMaintenanceView() { event in
   // code
}
```

Rather than it looking like this:
```swift
AddMaintenanceView { event in
   // code
}
```

# Screenshot
* N/A