### PR TITLE
CHORE: Add documentation to the `Contributor` model

### DIFF
--- a/Basic-Car-Maintenance/Shared/Models/Contributor.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Contributor.swift
@@ -7,16 +7,44 @@
 
 import Foundation
 
+/// A model representing a contributor.
+///  
+/// Contributors are people who have supported this project in any manner.
+///  
+/// - Note: In this project, we don't actually create this ``Contributor`` 
+/// anywhere, we are getting all the contributors from [GitHub's Repository Statistics
+/// API](https://api.github.com/repos/mikaelacaron/Basic-Car-Maintenance/contributors)
+///
+/// On status code of 200, we decode the response into ``SettingsViewModel/contributors``
+/// array of ``Contributor`` type and display them in ``ContributorsListView``.
 struct Contributor: Codable, Hashable, Identifiable {
+    
+    /// The handle for the GitHub user account
     let login: String
+    
+    /// The unique identifier for an account
     let id: Int
+    
+    /// The ID used to move between the REST API & the GraphQL API
     let nodeID: String
+    
+    /// The link to profile image of the user
     let avatarURL: String
+    
+    /// The link to user's avatar on Gravatar if they haven't uploaded an avatar directly.
+    /// - Warning: Deprecated by GitHub in 2014
     let gravatarID: String
+    
+    /// The endpoint for a user's profile data
     let url: String
+    
+    /// The url for overview of an account
     let htmlURL: String
+    
+    /// The number of Pull Requests successfully merged
     let contributions: Int
-
+    
+    /// Keys used in the HTTP Response
     enum CodingKeys: String, CodingKey {
         case login, id
         case nodeID = "nodeId"

--- a/Basic-Car-Maintenance/Shared/Models/Contributor.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Contributor.swift
@@ -38,7 +38,7 @@ struct Contributor: Codable, Hashable, Identifiable {
     /// The endpoint for a user's profile data
     let url: String
     
-    /// The url for overview of an account
+    /// The url to this account on GitHub
     let htmlURL: String
     
     /// The number of Pull Requests successfully merged

--- a/Basic-Car-Maintenance/Shared/Models/Contributor.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Contributor.swift
@@ -44,7 +44,7 @@ struct Contributor: Codable, Hashable, Identifiable {
     /// The number of Pull Requests successfully merged
     let contributions: Int
     
-    /// Keys used in the HTTP Response
+    /// Keys to be used for encoding and decoding.
     enum CodingKeys: String, CodingKey {
         case login, id
         case nodeID = "nodeId"

--- a/Basic-Car-Maintenance/Shared/Models/Contributor.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Contributor.swift
@@ -25,7 +25,7 @@ struct Contributor: Codable, Hashable, Identifiable {
     /// The unique identifier for an account
     let id: Int
     
-    /// The ID used to move between the REST API & the GraphQL API
+    /// The ID used to move between the REST API and the GraphQL API
     let nodeID: String
     
     /// The link to profile image of the user


### PR DESCRIPTION
# Documentation
* Closes #91 
* Xcode like documentation which serves as a guide when we do `Build Documentation` for this project

# How I Tested

Either `Option` + Click any identifier or use the `Build Documentation` feature of Xcode to avail this feature.

It also appears in autocompletion window.

# Screenshot
<img width="1065" alt="DocC" src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/61212965/4ddc6071-f3e2-43e1-9d03-26d2f67d240b">
