### PR TITLE
Add option to cache SPM packages

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Setup Config file
         run: |
           cp Basic-Car-Maintenance.xcconfig.template Basic-Car-Maintenance.xcconfig
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .build
+            .derivedData
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - name: Run Build Docs
         run: ./build-docc.sh
       - name: Setup Pages


### PR DESCRIPTION
# What it Does
* Closes #81 
* To make a documentation CI job run faster by caching the derived data folder along with build folder

# How I Tested
* Tested on my fork repo. Please check the [link](https://github.com/rizwankce/Basic-Car-Maintenance/actions/workflows/docc.yml) for the difference

# Notes
* Caching was able to save some time for the each build. For the first time since there is no cache it will run on usual time but from the second time onwards it will be little faster. 
* first run without cache takes `7m 31s` and second run with cache takes `5m 16s`

# Screenshot
![Screenshot 2023-10-09 at 12 24 53 PM](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/12063704/d4b642e1-9022-4d94-9e4f-b5c482a4c88b)
![Screenshot 2023-10-09 at 12 25 01 PM](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/12063704/4ea69d99-0e59-40ca-b06e-556723c132dd)

