### PR TITLE
101 update german localization

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -131,9 +131,9 @@ extension DashboardViewModel {
         
         var label: LocalizedStringResource {
             switch self {
-            case .oldestToNewest: "Oldest to Newest"
-            case .newestToOldest: "Newest to Oldest"
-            case .custom: "Custom"
+            case .oldestToNewest: LocalizedStringResource("Oldest to Newest", comment: "Sorting option that displays older items first.")
+            case .newestToOldest: LocalizedStringResource("Newest to Oldest", comment: "Sorting option that displays newer items first.")
+            case .custom: LocalizedStringResource("Custom", comment: "Sorting option that sorts items according to the user's preferences.")
             }
         }
     }

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -40,7 +40,15 @@
       }
     },
     "🦄 Mikaela Caron - Maintainer" : {
-      "comment" : "Link to maintainer Github account."
+      "comment" : "Link to maintainer Github account.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🦄 Mikaela Caron - Maintainer"
+          }
+        }
+      }
     },
     "Add" : {
       "comment" : "Label for button to add data",
@@ -119,6 +127,12 @@
             "value" : "Přidat první servisní záznam"
           }
         },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erste Wartung hinzufügen"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -152,6 +166,12 @@
     },
     "An Error Occurred" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es ist ein Fehler aufgetreten"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -161,11 +181,24 @@
       }
     },
     "Cancel" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        }
+      }
     },
     "Contributors" : {
       "comment" : "Link to contributors list.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitwirkende"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -175,7 +208,14 @@
       }
     },
     "Custom" : {
+      "comment" : "Sorting option that sorts items according to the user's preferences.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefiniert"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -232,6 +272,12 @@
     "Delete" : {
       "comment" : "Label to delete a vehicle",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Löschen"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -241,11 +287,24 @@
       }
     },
     "Edit" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bearbeiten"
+          }
+        }
+      }
     },
     "Failed To Add Vehicle. Unknown Error." : {
       "comment" : "Label to display error details.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fahrzeug konnte nicht hinzugefügt werden. Unbekannter Fehler."
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -256,6 +315,12 @@
     },
     "Failed To Delete Event" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Event konnte nicht gelöscht werden"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -267,6 +332,12 @@
     "Failed To Delete Vehicle" : {
       "comment" : "Label to dsplay title of the delete vehicle alert",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fahrzeug konnte nicht gelöscht werden."
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -278,6 +349,12 @@
     "Failed To Delete Vehicle\nDetails:%@" : {
       "comment" : "Label to display localized error description.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fahrzeug konnte nicht gelöscht werden.\nDetails: %@"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -398,7 +475,14 @@
       }
     },
     "Newest to Oldest" : {
+      "comment" : "Sorting option that displays newer items first.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neu vor alt"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -433,6 +517,12 @@
     "OK" : {
       "comment" : "Label to dismiss alert",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -442,7 +532,14 @@
       }
     },
     "Oldest to Newest" : {
+      "comment" : "Sorting option that displays older items first.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alt vor neu"
+          }
+        },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
@@ -680,7 +777,14 @@
       }
     },
     "Update" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisierung"
+          }
+        }
+      }
     },
     "Vehicle Make" : {
       "localizations" : {


### PR DESCRIPTION
# What it Does
* Closes #101 
* Updates missing german localization for new strings

# How I Tested
* Run the application

# Notes
There are a few anglicisms that I consider accepted in the german language–which is why I did not translate them but left them as they are. A good example for this is "Dashboard" which is a term used in German as well.