### PR TITLE
111 save last opened tab

### DIFF
--- a/Basic-Car-Maintenance/Shared/MainTabView.swift
+++ b/Basic-Car-Maintenance/Shared/MainTabView.swift
@@ -14,10 +14,10 @@ enum TabSelection: Int {
 
 @MainActor
 struct MainTabView: View {
+    @AppStorage("lastTabOpen") var selectedTab = TabSelection.dashboard
     @Environment(ActionService.self) var actionService
     @Environment(\.scenePhase) var scenePhase
     @State var authenticationViewModel = AuthenticationViewModel()
-    @State var selectedTab: TabSelection = .dashboard
     
     var body: some View {
         TabView(selection: $selectedTab) {


### PR DESCRIPTION
- persist  in AppStorage/UserDefaults

# What it Does
* Closes #111
* Persists the user's tab selecetion in UserDefaults

# How I Tested
* run the application
* select the "Settings" tab
* exited the app
* relaunch from Home Screen, confirming that the "Settings" screen is shown
* retried above steps with changing the tab selection to "Dashboard" again

# Notes
n/a

# Screenshot

https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/91844195/f8a60dda-148f-412b-a07d-e1ce5ab25e3d

