### PR TITLE
Issue 106: Improve - Use ScaledMetric on ContributorsListView for Use…

### DIFF
--- a/Basic-Car-Maintenance/Shared/Settings/Views/ContributorsProfileView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ContributorsProfileView.swift
@@ -11,7 +11,7 @@ struct ContributorsProfileView: View {
     
     let name: String
     let imgUrl: String
-    private let imgFrame: CGFloat = 30
+    @ScaledMetric(relativeTo: .largeTitle) var imgFrame: CGFloat = 50
 
     init(name: String, url: String) {
         self.name = name


### PR DESCRIPTION
# What it Does
* Closes #106 
* Describe what your change does
   Used the ScaledMetric modifier to adjust the user's profile picture size when enabling dynamic type


# How I Tested
* Launch the app
* Tap Settings in the tab bar
* Tap Contributors to show the list of contributors with their profile avatars
* Tap the home button or swipe up to get to the home screen
* Go to settings | Accessibility | Display & Text Size
* Tap Large Text
* Toggle Larger Accessibility Sizes to on
* Set a larger text size
* Navigate back to the home screen
* Open the app
* Tap Settings | Contributors
* Observe the larger profile icons


# Screenshot
*![Simulator Screenshot - iPhone 15 - 2023-10-09 at 21 35 09](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/22773854/1a4a578d-8e8f-4147-b184-1e8a89abdc74)