### PR TITLE
FIX: Set upper limit for dynamic type size on DatePicker

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/AddMaintenanceView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/AddMaintenanceView.swift
@@ -35,6 +35,7 @@ struct AddMaintenanceView: View {
                     Text("Date",
                          comment: "Date picker label")
                 }
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 
                 Section {
                     TextField(text: $notes,


### PR DESCRIPTION
# What it Does
* Closes #104 
* Prevents the text in DatePicker from truncating or vanishing on larger font sizes.

# Notes
* Available font sizes:
```swift
enum DynamicTypeSize {
    case xSmall
    case small
    case medium
    case large
    case xLarge
    case xxLarge
    case xxxLarge
    case accessibility1
    case accessibility2
    case accessibility3
    case accessibility4
    case accessibility5
    // ...
}

```
* Minimum deployment of this project is set to `iOS 17.0`. The lowest resolution device compatible for `iOS 17.0` would be `iPhone SE (2nd generation)`. For that resolution, largest size that fits without breaking is `DynamicTypeSize.accessibility2`.