### PR TITLE
Crash fix: Added document ID to vehicleToAdd

### DIFF
--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -56,9 +56,9 @@ final class SettingsViewModel {
             
             do {
                 let firestoreRef = try Firestore
-                                        .firestore()
-                                        .collection("vehicles")
-                                        .addDocument(from: vehicleToAdd)
+                    .firestore()
+                    .collection("vehicles")
+                    .addDocument(from: vehicleToAdd)
                 vehicleToAdd.id = firestoreRef.documentID
                 vehicles.append(vehicleToAdd)
             } catch {

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -55,11 +55,11 @@ final class SettingsViewModel {
             vehicleToAdd.userID = uid
             
             do {
-                try Firestore
-                    .firestore()
-                    .collection("vehicles")
-                    .addDocument(from: vehicleToAdd)
-                
+                let firestoreRef = try Firestore
+                                        .firestore()
+                                        .collection("vehicles")
+                                        .addDocument(from: vehicleToAdd)
+                vehicleToAdd.id = firestoreRef.documentID
                 vehicles.append(vehicleToAdd)
             } catch {
                 throw error


### PR DESCRIPTION
# What it Does
* Closes #117 
* Adds document ID to vehicleToAdd before appending it to `vehicles`  array

# How I Tested
1. Run application
2. Move to settings tab
3. Add a new vehicle
4. Immediately delete the newly added vehicle

# Screen recording
https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/32197474/ac28c775-5063-47cd-985d-8321d47cd632