### PR TITLE
Make version info copyable

### DIFF
--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -297,6 +297,9 @@
         }
       }
     },
+    "Copied!" : {
+      "comment" : "Text to notify user that app version was copied"
+    },
     "Custom" : {
       "comment" : "Sorting option that sorts items according to the user's preferences.",
       "localizations" : {

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @State private var viewModel: SettingsViewModel
@@ -15,6 +16,8 @@ struct SettingsView: View {
     @Environment(ActionService.self) var actionService
     @Environment(\.scenePhase) var scenePhase
     @State private var errorDetails: Error?
+    @State private var copiedAppVersion: Bool = false
+    private let appVersion = "Version \(Bundle.main.versionNumber) (\(Bundle.main.buildNumber))"
     
     init(authenticationViewModel: AuthenticationViewModel) {
         let settingsViewModel = SettingsViewModel(authenticationViewModel: authenticationViewModel)
@@ -119,7 +122,26 @@ struct SettingsView: View {
                     }
                 }
                 // swiftlint:disable:next line_length
-                Text("Version \(Bundle.main.versionNumber) (\(Bundle.main.buildNumber))", comment: "Label to display version and build number.")
+                Text(LocalizedStringKey(stringLiteral: appVersion), comment: "Label to display version and build number.")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .onLongPressGesture {
+                        let clipboard = UIPasteboard.general
+                        clipboard.setValue(appVersion, forPasteboardType: UTType.plainText.identifier)
+                        copiedAppVersion = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            copiedAppVersion = false
+                        }
+                    }
+                    .overlay {
+                        // A toast view to notify the user of version copy
+                        Text("Copied!", comment: "Text to notify user that app version was copied").font(.callout)
+                            .padding(8)
+                            .background(.black)
+                            .foregroundStyle(.white)
+                            .clipShape(Capsule())
+                            .opacity(copiedAppVersion ? 1 : 0)
+                            .animation(.linear(duration: 0.2), value: copiedAppVersion)
+                    }
             }
             .navigationDestination(isPresented: $isShowingAddVehicle) {
                 AddVehicleView() { vehicle in

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @State private var showAddVehicleError = false
     @Environment(ActionService.self) var actionService
     @Environment(\.scenePhase) var scenePhase
+    @Environment(\.colorScheme) var colorScheme
     @State private var errorDetails: Error?
     @State private var copiedAppVersion: Bool = false
     private let appVersion = "Version \(Bundle.main.versionNumber) (\(Bundle.main.buildNumber))"
@@ -134,10 +135,11 @@ struct SettingsView: View {
                     }
                     .overlay {
                         // A toast view to notify the user of version copy
-                        Text("Copied!", comment: "Text to notify user that app version was copied").font(.callout)
+                        Text("Copied!", comment: "Text to notify user that app version was copied")
+                            .font(.callout)
                             .padding(8)
-                            .background(.black)
-                            .foregroundStyle(.white)
+                            .foregroundStyle(colorScheme == .light ? .white : .black)
+                            .background(colorScheme == .light ? .black : .white)
                             .clipShape(Capsule())
                             .opacity(copiedAppVersion ? 1 : 0)
                             .animation(.linear(duration: 0.2), value: copiedAppVersion)


### PR DESCRIPTION
Added a text overlay to show copy success as a toast

# What it Does
* Fixes #110 
* Centered app version text and added another text as an overlay to serve as a toast notifier (see video attached)

# How I Tested
* Ran the application on an iPhone 15 simulator with iOS 17.0
* Switched to `Settings` tab
* Scroll to app version & long press on the text

# Notes
* Makes use of the `UniformTypeIdentifiers` framework

# Video
https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/103429618/3f233bd1-65b3-4059-96f1-2447240a4cc6

