### PR TITLE
140- Removed GravatarID  from the Contributor model

### DIFF
--- a/Basic-Car-Maintenance-Tests/Shared/Models/ContributorTests.swift
+++ b/Basic-Car-Maintenance-Tests/Shared/Models/ContributorTests.swift
@@ -17,7 +17,6 @@ final class ContributorTests: XCTestCase {
     "id": 12915108,
     "node_id": "MDQ6VXNlcjEyOTE1MTA4",
     "avatar_url": "https://avatars.githubusercontent.com/u/12915108?v=4",
-    "gravatar_id": "",
     "url": "https://api.github.com/users/Drag0ndust",
     "html_url": "https://github.com/Drag0ndust",
     "contributions": 0
@@ -44,7 +43,6 @@ final class ContributorTests: XCTestCase {
         XCTAssertEqual(sut.id, 12915108)
         XCTAssertEqual(sut.nodeID, "MDQ6VXNlcjEyOTE1MTA4")
         XCTAssertEqual(sut.avatarURL, "https://avatars.githubusercontent.com/u/12915108?v=4")
-        XCTAssertEqual(sut.gravatarID, "")
         XCTAssertEqual(sut.url, "https://api.github.com/users/Drag0ndust")
         XCTAssertEqual(sut.htmlURL, "https://github.com/Drag0ndust")
         XCTAssertEqual(sut.contributions, 0)
@@ -55,7 +53,7 @@ final class ContributorTests: XCTestCase {
                                       id: 12915108,
                                       nodeID: "MDQ6VXNlcjEyOTE1MTA4",
                                       avatarURL: "https://avatars.githubusercontent.com/u/12915108?v=4",
-                                      gravatarID: "", url: "https://api.github.com/users/Drag0ndust",
+                                      url: "https://api.github.com/users/Drag0ndust",
                                       htmlURL: "https://github.com/Drag0ndust",
                                       contributions: 0)
         

--- a/Basic-Car-Maintenance/Shared/Models/Contributor.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Contributor.swift
@@ -31,10 +31,6 @@ struct Contributor: Codable, Hashable, Identifiable {
     /// The link to profile image of the user
     let avatarURL: String
     
-    /// The link to user's avatar on Gravatar if they haven't uploaded an avatar directly.
-    /// - Warning: Deprecated by GitHub in 2014
-    let gravatarID: String
-    
     /// The endpoint for a user's profile data
     let url: String
     
@@ -49,7 +45,6 @@ struct Contributor: Codable, Hashable, Identifiable {
         case login, id
         case nodeID = "nodeId"
         case avatarURL = "avatarUrl"
-        case gravatarID = "gravatarId"
         case url
         case htmlURL = "htmlUrl"
         case contributions


### PR DESCRIPTION
# What it Does
* Closes #140 
* Removed GravatorID from the Contributor model and Contributor Tests

# How I Tested
* Run the application
* Navigated to the settings Tab
* Select Contributors
* Check the Contributors listing page
* I also run the test case.
