### PR TITLE
17 Alternate App Icons

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		023057F22ACFAD79006C5A73 /* EditEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */; };
+		8014A4CD2AD755C8005B51F6 /* Basic-Car-Maintenance.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */; };
 		898009792AD1899700604E7C /* ContributorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898009782AD1899700604E7C /* ContributorTests.swift */; };
 		8AEE816F2ACF37F800FC0C2A /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE816E2ACF37F800FC0C2A /* Action.swift */; };
 		8AEE81722ACF384D00FC0C2A /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE81712ACF384D00FC0C2A /* MainTabView.swift */; };
@@ -537,6 +538,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FF5D13AF2A86C2D800BC9BD6 /* Preview Assets.xcassets in Resources */,
+				8014A4CD2AD755C8005B51F6 /* Basic-Car-Maintenance.xcconfig in Resources */,
 				FFC8CDA42AA385E800D129A6 /* GoogleService-Info.plist in Resources */,
 				FF5D13AB2A86C2D800BC9BD6 /* Assets.xcassets in Resources */,
 				FF755B432A90915E00F49A13 /* Localizable.xcstrings in Resources */,
@@ -782,6 +784,7 @@
 		};
 		FF5D13C92A86C2D800BC9BD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8014A4CD2AD755C8005B51F6 /* Basic-Car-Maintenance.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */; };
 		8014A4CF2AD75928005B51F6 /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4CE2AD75928005B51F6 /* AppIcon.swift */; };
 		8014A4D12AD76034005B51F6 /* ChooseAppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4D02AD76034005B51F6 /* ChooseAppIconView.swift */; };
+		8014A4D32AD77C92005B51F6 /* ChooseAppIconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4D22AD77C92005B51F6 /* ChooseAppIconViewModel.swift */; };
 		898009792AD1899700604E7C /* ContributorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898009782AD1899700604E7C /* ContributorTests.swift */; };
 		8AEE816F2ACF37F800FC0C2A /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE816E2ACF37F800FC0C2A /* Action.swift */; };
 		8AEE81722ACF384D00FC0C2A /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE81712ACF384D00FC0C2A /* MainTabView.swift */; };
@@ -96,6 +97,7 @@
 		023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEventDetailView.swift; sourceTree = "<group>"; };
 		8014A4CE2AD75928005B51F6 /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		8014A4D02AD76034005B51F6 /* ChooseAppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseAppIconView.swift; sourceTree = "<group>"; };
+		8014A4D22AD77C92005B51F6 /* ChooseAppIconViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseAppIconViewModel.swift; sourceTree = "<group>"; };
 		898009782AD1899700604E7C /* ContributorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorTests.swift; sourceTree = "<group>"; };
 		8AEE816E2ACF37F800FC0C2A /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		8AEE81712ACF384D00FC0C2A /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 			children = (
 				FFC67D1C2AAEF7920073B338 /* SettingsViewModel.swift */,
 				FF748B5D2AB3589C004748A5 /* AuthenticationViewModel.swift */,
+				8014A4D22AD77C92005B51F6 /* ChooseAppIconViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -613,6 +616,7 @@
 				8AEE816F2ACF37F800FC0C2A /* Action.swift in Sources */,
 				FFBFE0972A98F7CB000A9BEB /* AddVehicleView.swift in Sources */,
 				E584996A2ACDDAFF00634660 /* Contributor.swift in Sources */,
+				8014A4D32AD77C92005B51F6 /* ChooseAppIconViewModel.swift in Sources */,
 				8014A4CF2AD75928005B51F6 /* AppIcon.swift in Sources */,
 				FFC67D1D2AAEF7920073B338 /* SettingsViewModel.swift in Sources */,
 				FF755B3C2A908E3E00F49A13 /* DashboardView.swift in Sources */,

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		E58499692ACDDAFF00634660 /* Contributor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contributor.swift; sourceTree = "<group>"; };
 		FF0813562AD0A83000910EFA /* UITests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UITests.xcconfig; sourceTree = "<group>"; };
 		FF0813572AD0A92700910EFA /* Widget.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Widget.xcconfig; sourceTree = "<group>"; };
+		FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Basic-Car-Maintenance.xcconfig"; sourceTree = SOURCE_ROOT; };
 		FF09FC902AB6FF44006BE61A /* AuthenticationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationView.swift; sourceTree = "<group>"; };
 		FF3DDF512AA4D28F009D91C4 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		FF5D13A32A86C2D600BC9BD6 /* Basic-Car-Maintenance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Basic-Car-Maintenance.app"; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		023057F22ACFAD79006C5A73 /* EditEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */; };
-		8014A4CD2AD755C8005B51F6 /* Basic-Car-Maintenance.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */; };
 		8014A4CF2AD75928005B51F6 /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4CE2AD75928005B51F6 /* AppIcon.swift */; };
 		8014A4D12AD76034005B51F6 /* ChooseAppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4D02AD76034005B51F6 /* ChooseAppIconView.swift */; };
 		8014A4D32AD77C92005B51F6 /* ChooseAppIconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4D22AD77C92005B51F6 /* ChooseAppIconViewModel.swift */; };
@@ -107,7 +106,6 @@
 		E58499692ACDDAFF00634660 /* Contributor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contributor.swift; sourceTree = "<group>"; };
 		FF0813562AD0A83000910EFA /* UITests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UITests.xcconfig; sourceTree = "<group>"; };
 		FF0813572AD0A92700910EFA /* Widget.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Widget.xcconfig; sourceTree = "<group>"; };
-		FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Basic-Car-Maintenance.xcconfig"; sourceTree = SOURCE_ROOT; };
 		FF09FC902AB6FF44006BE61A /* AuthenticationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationView.swift; sourceTree = "<group>"; };
 		FF3DDF512AA4D28F009D91C4 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		FF5D13A32A86C2D600BC9BD6 /* Basic-Car-Maintenance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Basic-Car-Maintenance.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -225,7 +223,6 @@
 			isa = PBXGroup;
 			children = (
 				FFBE79BA2AD0A48C0005524E /* Configurations */,
-				FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */,
 				FF5D13A52A86C2D600BC9BD6 /* Basic-Car-Maintenance */,
 				FFDADF822ACD35A100DDEF79 /* Basic-Car-Maintenance-Widget */,
 				FF5D13B72A86C2D800BC9BD6 /* Basic-Car-Maintenance-Tests */,
@@ -547,7 +544,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				FF5D13AF2A86C2D800BC9BD6 /* Preview Assets.xcassets in Resources */,
-				8014A4CD2AD755C8005B51F6 /* Basic-Car-Maintenance.xcconfig in Resources */,
 				FFC8CDA42AA385E800D129A6 /* GoogleService-Info.plist in Resources */,
 				FF5D13AB2A86C2D800BC9BD6 /* Assets.xcassets in Resources */,
 				FF755B432A90915E00F49A13 /* Localizable.xcstrings in Resources */,
@@ -796,7 +792,6 @@
 		};
 		FF5D13C92A86C2D800BC9BD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "";
@@ -837,7 +832,6 @@
 		};
 		FF5D13CA2A86C2D800BC9BD6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "";

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 			isa = PBXGroup;
 			children = (
 				FFBE79BA2AD0A48C0005524E /* Configurations */,
+				FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */,
 				FF5D13A52A86C2D600BC9BD6 /* Basic-Car-Maintenance */,
 				FFDADF822ACD35A100DDEF79 /* Basic-Car-Maintenance-Widget */,
 				FF5D13B72A86C2D800BC9BD6 /* Basic-Car-Maintenance-Tests */,
@@ -833,6 +834,7 @@
 		};
 		FF5D13CA2A86C2D800BC9BD6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "";

--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		023057F22ACFAD79006C5A73 /* EditEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */; };
 		8014A4CD2AD755C8005B51F6 /* Basic-Car-Maintenance.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */; };
+		8014A4CF2AD75928005B51F6 /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4CE2AD75928005B51F6 /* AppIcon.swift */; };
+		8014A4D12AD76034005B51F6 /* ChooseAppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4D02AD76034005B51F6 /* ChooseAppIconView.swift */; };
 		898009792AD1899700604E7C /* ContributorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898009782AD1899700604E7C /* ContributorTests.swift */; };
 		8AEE816F2ACF37F800FC0C2A /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE816E2ACF37F800FC0C2A /* Action.swift */; };
 		8AEE81722ACF384D00FC0C2A /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE81712ACF384D00FC0C2A /* MainTabView.swift */; };
@@ -92,6 +94,8 @@
 
 /* Begin PBXFileReference section */
 		023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEventDetailView.swift; sourceTree = "<group>"; };
+		8014A4CE2AD75928005B51F6 /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
+		8014A4D02AD76034005B51F6 /* ChooseAppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseAppIconView.swift; sourceTree = "<group>"; };
 		898009782AD1899700604E7C /* ContributorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorTests.swift; sourceTree = "<group>"; };
 		8AEE816E2ACF37F800FC0C2A /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		8AEE81712ACF384D00FC0C2A /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
@@ -337,6 +341,7 @@
 				E58499692ACDDAFF00634660 /* Contributor.swift */,
 				FFBFE0922A98F212000A9BEB /* Vehicle.swift */,
 				8AEE816E2ACF37F800FC0C2A /* Action.swift */,
+				8014A4CE2AD75928005B51F6 /* AppIcon.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -345,6 +350,7 @@
 			isa = PBXGroup;
 			children = (
 				FF755B3D2A908E7A00F49A13 /* SettingsView.swift */,
+				8014A4D02AD76034005B51F6 /* ChooseAppIconView.swift */,
 				FFBFE0962A98F7CB000A9BEB /* AddVehicleView.swift */,
 				E58499652ACDDA8B00634660 /* ContributorsListView.swift */,
 				E58499672ACDDA9A00634660 /* ContributorsProfileView.swift */,
@@ -607,12 +613,14 @@
 				8AEE816F2ACF37F800FC0C2A /* Action.swift in Sources */,
 				FFBFE0972A98F7CB000A9BEB /* AddVehicleView.swift in Sources */,
 				E584996A2ACDDAFF00634660 /* Contributor.swift in Sources */,
+				8014A4CF2AD75928005B51F6 /* AppIcon.swift in Sources */,
 				FFC67D1D2AAEF7920073B338 /* SettingsViewModel.swift in Sources */,
 				FF755B3C2A908E3E00F49A13 /* DashboardView.swift in Sources */,
 				8AEE81722ACF384D00FC0C2A /* MainTabView.swift in Sources */,
 				E58499662ACDDA8B00634660 /* ContributorsListView.swift in Sources */,
 				FFBFE0932A98F212000A9BEB /* Vehicle.swift in Sources */,
 				FF5D13A72A86C2D600BC9BD6 /* BasicCarMaintenanceApp.swift in Sources */,
+				8014A4D12AD76034005B51F6 /* ChooseAppIconView.swift in Sources */,
 				FF748B5E2AB3589C004748A5 /* AuthenticationViewModel.swift in Sources */,
 				FF755B462A90969D00F49A13 /* Bundle+extension.swift in Sources */,
 				FFAA56ED2AC8905C000120EE /* Documentation.docc in Sources */,
@@ -787,6 +795,8 @@
 			baseConfigurationReference = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "";
+				"ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES[sdk=*]" = "AppIcon-car-red AppIcon-car-yellow AppIcon-car-dark AppIcon-car-orange AppIcon-car-black";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Basic-Car-Maintenance/Basic_Car_Maintenance.entitlements";
@@ -826,6 +836,7 @@
 			baseConfigurationReference = FF098EFA2AB3424E003EC0FE /* Basic-Car-Maintenance.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Basic-Car-Maintenance/Basic_Car_Maintenance.entitlements";

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -151,7 +151,7 @@
       }
     },
     "Add Vehicle" : {
-      "comment" : "Label to add a vehicle.\nNavigation title for Add Vehicle View",
+      "comment" : "Navigation title for Add Vehicle View\nLabel to add a vehicle.",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -320,9 +320,6 @@
 
     },
     "Choose App Icon" : {
-
-    },
-    "Choose the App Icon that you would like to see on your Home Screen." : {
 
     },
     "Contributors" : {
@@ -1359,6 +1356,9 @@
           }
         }
       }
+    },
+    "This App Icon will appear on your Home Screen." : {
+
     },
     "Title" : {
       "comment" : "Maintenance event title text field header",

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -151,7 +151,7 @@
       }
     },
     "Add Vehicle" : {
-      "comment" : "Navigation title for Add Vehicle View\nLabel to add a vehicle.",
+      "comment" : "Label to add a vehicle.\nNavigation title for Add Vehicle View",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -315,6 +315,15 @@
           }
         }
       }
+    },
+    "Change App Icon" : {
+
+    },
+    "Choose App Icon" : {
+
+    },
+    "Choose the App Icon that you would like to see on your Home Screen." : {
+
     },
     "Contributors" : {
       "comment" : "Link to contributors list.",

--- a/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
+++ b/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
@@ -1,3 +1,10 @@
+//
+//  ChooseAppIconView.swift
+//  Basic-Car-Maintenance
+//
+//  Created by Daniel Lyons on 10/11/23.
+//
+
 import UIKit
 
 enum AppIcon: String, CaseIterable, Identifiable {

--- a/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
+++ b/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
@@ -1,43 +1,4 @@
 import UIKit
-import Observation
-
-/// The ViewModel responsible for allowing users to change the AppIcon
-@Observable class ChangeAppIconViewModel {
-  private(set) var selectedAppIcon: AppIcon
-  
-  init() {
-    if let iconName = UIApplication.shared.alternateIconName,
-       let appIcon = AppIcon(rawValue: iconName) {
-      self._selectedAppIcon = appIcon
-    } else {
-      self._selectedAppIcon = .primary
-    }
-  }
-  
-  func updateAppIcon(to icon: AppIcon) {
-    let previousAppIcon = selectedAppIcon
-    selectedAppIcon = icon
-    
-    Task { @MainActor in
-      guard UIApplication.shared.alternateIconName != icon.iconName else {
-         print("No need to update icon since we're already using this icon.")
-        return
-      }
-      
-      do {
-        try await UIApplication.shared.setAlternateIconName(icon.iconName)
-        print("Successfully updated icon.")
-      } catch {
-        // We're only logging the error here and not actively handling the app icon failure
-        // since it's very unlikely to fail.
-        print("Updating icon to \(String(describing: icon.iconName)) failed.")
-        
-        // Restore previous app icon
-        selectedAppIcon = previousAppIcon
-      }
-    }
-  }
-}
 
 enum AppIcon: String, CaseIterable, Identifiable {
   case primary = "AppIcon"
@@ -48,6 +9,8 @@ enum AppIcon: String, CaseIterable, Identifiable {
   case carOrange = "AppIcon-car-orange"
   
   var id: String { rawValue }
+  
+  /// the name of the icon in the App Bundle.
   var iconName: String? {
     switch self {
     /// returns `nil`. Use this case to reset the app icon back to its primary icon.
@@ -58,6 +21,7 @@ enum AppIcon: String, CaseIterable, Identifiable {
     }
   }
   
+  /// A UI presentable string.
   var description: String {
     switch self {
     case .primary:

--- a/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
+++ b/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
@@ -1,0 +1,86 @@
+//
+//  AppIcon.swift
+//  Basic-Car-Maintenance
+//
+//  Created by Daniel Lyons on 10/11/23.
+//
+import UIKit
+import Observation
+
+/// The ViewModel responsible for allowing users to change the AppIcon
+@Observable class ChangeAppIconViewModel {
+  var selectedAppIcon: AppIcon
+  
+  init() {
+    if let iconName = UIApplication.shared.alternateIconName,
+       let appIcon = AppIcon(rawValue: iconName) {
+      self.selectedAppIcon = appIcon
+    } else {
+      self.selectedAppIcon = .primary
+    }
+  }
+  
+  func updateAppIcon(to icon: AppIcon) {
+    let previousAppIcon = selectedAppIcon
+    selectedAppIcon = icon
+    
+    Task { @MainActor in
+      guard UIApplication.shared.alternateIconName != icon.iconName else {
+        // No need to update since we're already using this icon.
+        return
+      }
+      
+      do {
+        try await UIApplication.shared.setAlternateIconName(icon.iconName)
+      } catch {
+        // We're only logging the error here and not actively handling the app icon failure
+        // since it's very unlikely to fail.
+        print("Updating icon to \(String(describing: icon.iconName)) failed.")
+        
+        // Restore previous app icon
+        selectedAppIcon = previousAppIcon
+      }
+    }
+  }
+}
+
+enum AppIcon: String, CaseIterable, Identifiable {
+  case primary = "AppIcon"
+  case carDark = "AppIcon-car-dark"
+  case carRed = "AppIcon-car-red"
+  case carYellow = "AppIcon-car-yellow"
+  case carBlack = "AppIcon-car-black"
+  case carOrange = "AppIcon-car-orange"
+  
+  var id: String{ rawValue }
+  var iconName: String? {
+    switch self {
+      /// returns `nil`. Use this case to reset the app icon back to its primary icon.
+      case .primary:
+        return nil
+      default:
+        return rawValue
+    }
+  }
+  
+  var description: String {
+    switch self {
+      case .primary:
+        return "Default"
+      case .carDark:
+        return "Dark Mode"
+      case .carRed:
+        return "Red Car"
+      case .carYellow:
+        return "Yellow Car"
+      case .carBlack:
+        return "Black Car"
+      case .carOrange:
+        return "Orange Car"
+    }
+  }
+  
+  var preview: UIImage {
+    UIImage(named: rawValue + "-Preview") ?? UIImage()
+  }
+}

--- a/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
+++ b/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
@@ -1,22 +1,16 @@
-//
-//  AppIcon.swift
-//  Basic-Car-Maintenance
-//
-//  Created by Daniel Lyons on 10/11/23.
-//
 import UIKit
 import Observation
 
 /// The ViewModel responsible for allowing users to change the AppIcon
 @Observable class ChangeAppIconViewModel {
-  var selectedAppIcon: AppIcon
+  private(set) var selectedAppIcon: AppIcon
   
   init() {
     if let iconName = UIApplication.shared.alternateIconName,
        let appIcon = AppIcon(rawValue: iconName) {
-      self.selectedAppIcon = appIcon
+      self._selectedAppIcon = appIcon
     } else {
-      self.selectedAppIcon = .primary
+      self._selectedAppIcon = .primary
     }
   }
   
@@ -26,12 +20,13 @@ import Observation
     
     Task { @MainActor in
       guard UIApplication.shared.alternateIconName != icon.iconName else {
-        // No need to update since we're already using this icon.
+         print("No need to update icon since we're already using this icon.")
         return
       }
       
       do {
         try await UIApplication.shared.setAlternateIconName(icon.iconName)
+        print("Successfully updated icon.")
       } catch {
         // We're only logging the error here and not actively handling the app icon failure
         // since it's very unlikely to fail.
@@ -52,35 +47,35 @@ enum AppIcon: String, CaseIterable, Identifiable {
   case carBlack = "AppIcon-car-black"
   case carOrange = "AppIcon-car-orange"
   
-  var id: String{ rawValue }
+  var id: String { rawValue }
   var iconName: String? {
     switch self {
-      /// returns `nil`. Use this case to reset the app icon back to its primary icon.
-      case .primary:
-        return nil
-      default:
-        return rawValue
+    /// returns `nil`. Use this case to reset the app icon back to its primary icon.
+    case .primary:
+      return nil
+    default:
+      return rawValue
     }
   }
   
   var description: String {
     switch self {
-      case .primary:
-        return "Default"
-      case .carDark:
-        return "Dark Mode"
-      case .carRed:
-        return "Red Car"
-      case .carYellow:
-        return "Yellow Car"
-      case .carBlack:
-        return "Black Car"
-      case .carOrange:
-        return "Orange Car"
+    case .primary:
+      return "Default"
+    case .carDark:
+      return "Dark Mode"
+    case .carRed:
+      return "Red Car"
+    case .carYellow:
+      return "Yellow Car"
+    case .carBlack:
+      return "Black Car"
+    case .carOrange:
+      return "Orange Car"
     }
   }
   
   var preview: UIImage {
-    UIImage(named: rawValue + "-Preview") ?? UIImage()
+    UIImage(named: rawValue) ?? UIImage()
   }
 }

--- a/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
+++ b/Basic-Car-Maintenance/Shared/Models/AppIcon.swift
@@ -8,45 +8,45 @@
 import UIKit
 
 enum AppIcon: String, CaseIterable, Identifiable {
-  case primary = "AppIcon"
-  case carDark = "AppIcon-car-dark"
-  case carRed = "AppIcon-car-red"
-  case carYellow = "AppIcon-car-yellow"
-  case carBlack = "AppIcon-car-black"
-  case carOrange = "AppIcon-car-orange"
-  
-  var id: String { rawValue }
-  
-  /// the name of the icon in the App Bundle.
-  var iconName: String? {
-    switch self {
-    /// returns `nil`. Use this case to reset the app icon back to its primary icon.
-    case .primary:
-      return nil
-    default:
-      return rawValue
+    case primary = "AppIcon"
+    case carDark = "AppIcon-car-dark"
+    case carRed = "AppIcon-car-red"
+    case carYellow = "AppIcon-car-yellow"
+    case carBlack = "AppIcon-car-black"
+    case carOrange = "AppIcon-car-orange"
+    
+    var id: String { rawValue }
+    
+    /// the name of the icon in the App Bundle.
+    var iconName: String? {
+        switch self {
+            /// returns `nil`. Use this case to reset the app icon back to its primary icon.
+        case .primary:
+            return nil
+        default:
+            return rawValue
+        }
     }
-  }
-  
-  /// A UI presentable string.
-  var description: String {
-    switch self {
-    case .primary:
-      return "Default"
-    case .carDark:
-      return "Dark Mode"
-    case .carRed:
-      return "Red Car"
-    case .carYellow:
-      return "Yellow Car"
-    case .carBlack:
-      return "Black Car"
-    case .carOrange:
-      return "Orange Car"
+    
+    /// A UI presentable string.
+    var description: String {
+        switch self {
+        case .primary:
+            return "Default"
+        case .carDark:
+            return "Dark Mode"
+        case .carRed:
+            return "Red Car"
+        case .carYellow:
+            return "Yellow Car"
+        case .carBlack:
+            return "Black Car"
+        case .carOrange:
+            return "Orange Car"
+        }
     }
-  }
-  
-  var preview: UIImage {
-    UIImage(named: rawValue) ?? UIImage()
-  }
+    
+    var preview: UIImage {
+        UIImage(named: rawValue) ?? UIImage()
+    }
 }

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/ChooseAppIconViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/ChooseAppIconViewModel.swift
@@ -1,3 +1,10 @@
+//
+//  ChooseAppIconView.swift
+//  Basic-Car-Maintenance
+//
+//  Created by Daniel Lyons on 10/11/23.
+//
+
 import UIKit
 import Observation
 
@@ -20,17 +27,20 @@ import Observation
     
     Task { @MainActor in
       guard UIApplication.shared.alternateIconName != icon.iconName else {
-        print("No need to update icon since we're already using this icon.")
+        // No need to update icon since we're already using this icon.
         return
       }
       
       do {
         try await UIApplication.shared.setAlternateIconName(icon.iconName)
-        print("Successfully updated icon.")
       } catch {
+        let feedbackGenerator = UINotificationFeedbackGenerator()
+        feedbackGenerator.prepare()
+        
         // We're only logging the error here and not actively handling the app icon failure
         // since it's very unlikely to fail.
         print("Updating icon to \(String(describing: icon.iconName)) failed.")
+        feedbackGenerator.notificationOccurred(.error)
         
         // Restore previous app icon
         selectedAppIcon = previousAppIcon

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/ChooseAppIconViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/ChooseAppIconViewModel.swift
@@ -10,41 +10,41 @@ import Observation
 
 /// The ViewModel responsible for allowing users to change the AppIcon
 @Observable class ChooseAppIconViewModel {
-  private(set) var selectedAppIcon: AppIcon
-  
-  init() {
-    if let iconName = UIApplication.shared.alternateIconName,
-       let appIcon = AppIcon(rawValue: iconName) {
-      self._selectedAppIcon = appIcon
-    } else {
-      self._selectedAppIcon = .primary
-    }
-  }
-  
-  func updateAppIcon(to icon: AppIcon) {
-    let previousAppIcon = selectedAppIcon
-    selectedAppIcon = icon
+    private(set) var selectedAppIcon: AppIcon
     
-    Task { @MainActor in
-      guard UIApplication.shared.alternateIconName != icon.iconName else {
-        // No need to update icon since we're already using this icon.
-        return
-      }
-      
-      do {
-        try await UIApplication.shared.setAlternateIconName(icon.iconName)
-      } catch {
-        let feedbackGenerator = UINotificationFeedbackGenerator()
-        feedbackGenerator.prepare()
-        
-        // We're only logging the error here and not actively handling the app icon failure
-        // since it's very unlikely to fail.
-        print("Updating icon to \(String(describing: icon.iconName)) failed.")
-        feedbackGenerator.notificationOccurred(.error)
-        
-        // Restore previous app icon
-        selectedAppIcon = previousAppIcon
-      }
+    init() {
+        if let iconName = UIApplication.shared.alternateIconName,
+           let appIcon = AppIcon(rawValue: iconName) {
+            self._selectedAppIcon = appIcon
+        } else {
+            self._selectedAppIcon = .primary
+        }
     }
-  }
+    
+    func updateAppIcon(to icon: AppIcon) {
+        let previousAppIcon = selectedAppIcon
+        selectedAppIcon = icon
+        
+        Task { @MainActor in
+            guard UIApplication.shared.alternateIconName != icon.iconName else {
+                // No need to update icon since we're already using this icon.
+                return
+            }
+            
+            do {
+                try await UIApplication.shared.setAlternateIconName(icon.iconName)
+            } catch {
+                let feedbackGenerator = UINotificationFeedbackGenerator()
+                feedbackGenerator.prepare()
+                
+                // We're only logging the error here and not actively handling the app icon failure
+                // since it's very unlikely to fail.
+                print("Updating icon to \(String(describing: icon.iconName)) failed.")
+                feedbackGenerator.notificationOccurred(.error)
+                
+                // Restore previous app icon
+                selectedAppIcon = previousAppIcon
+            }
+        }
+    }
 }

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/ChooseAppIconViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/ChooseAppIconViewModel.swift
@@ -1,0 +1,40 @@
+import UIKit
+import Observation
+
+/// The ViewModel responsible for allowing users to change the AppIcon
+@Observable class ChooseAppIconViewModel {
+  private(set) var selectedAppIcon: AppIcon
+  
+  init() {
+    if let iconName = UIApplication.shared.alternateIconName,
+       let appIcon = AppIcon(rawValue: iconName) {
+      self._selectedAppIcon = appIcon
+    } else {
+      self._selectedAppIcon = .primary
+    }
+  }
+  
+  func updateAppIcon(to icon: AppIcon) {
+    let previousAppIcon = selectedAppIcon
+    selectedAppIcon = icon
+    
+    Task { @MainActor in
+      guard UIApplication.shared.alternateIconName != icon.iconName else {
+        print("No need to update icon since we're already using this icon.")
+        return
+      }
+      
+      do {
+        try await UIApplication.shared.setAlternateIconName(icon.iconName)
+        print("Successfully updated icon.")
+      } catch {
+        // We're only logging the error here and not actively handling the app icon failure
+        // since it's very unlikely to fail.
+        print("Updating icon to \(String(describing: icon.iconName)) failed.")
+        
+        // Restore previous app icon
+        selectedAppIcon = previousAppIcon
+      }
+    }
+  }
+}

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -13,13 +13,11 @@ import Foundation
 final class SettingsViewModel {
     let authenticationViewModel: AuthenticationViewModel
     var contributors: [Contributor]?
-  var chooseAppIconViewModel: ChooseAppIconViewModel
     
     var vehicles = [Vehicle]()
     
     init(authenticationViewModel: AuthenticationViewModel) {
         self.authenticationViewModel = authenticationViewModel
-        self.chooseAppIconViewModel = .init()
     }
     
     let urls: [String: URL] = [

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -13,7 +13,7 @@ import Foundation
 final class SettingsViewModel {
     let authenticationViewModel: AuthenticationViewModel
     var contributors: [Contributor]?
-  var chooseAppIconViewModel: ChangeAppIconViewModel
+  var chooseAppIconViewModel: ChooseAppIconViewModel
     
     var vehicles = [Vehicle]()
     

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -13,11 +13,13 @@ import Foundation
 final class SettingsViewModel {
     let authenticationViewModel: AuthenticationViewModel
     var contributors: [Contributor]?
+  var chooseAppIconViewModel: ChangeAppIconViewModel
     
     var vehicles = [Vehicle]()
     
     init(authenticationViewModel: AuthenticationViewModel) {
         self.authenticationViewModel = authenticationViewModel
+        self.chooseAppIconViewModel = .init()
     }
     
     let urls: [String: URL] = [

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct ChooseAppIconView: View {
-  @Bindable var viewModel: ChangeAppIconViewModel
+  @State var viewModel: ChangeAppIconViewModel = .init()
   
-  func isSelected(_ icon: AppIcon) -> Bool {
+  private func isSelected(_ icon: AppIcon) -> Bool {
     return viewModel.selectedAppIcon == icon
   }
   
@@ -22,7 +22,11 @@ struct ChooseAppIconView: View {
     
     return Form {
       Section {
-        Text("Choose the App Icon that you would like to see on your Home Screen.")
+        HStack {
+          Image(systemName: "apps.iphone")
+            .font(.title)
+          Text("This App Icon will appear on your Home Screen.")
+        }
       }
       
       LazyVGrid(columns: columns) {
@@ -30,13 +34,11 @@ struct ChooseAppIconView: View {
           IconChoice(icon: icon, isSelected: self.isSelected(icon))
             .onTapGesture {
               withAnimation {
-                viewModel.selectedAppIcon = icon
+                viewModel.updateAppIcon(to: icon)
               }
             }
         }
-        
       }
-      
     }
     .navigationTitle("Choose App Icon")
   }
@@ -47,16 +49,22 @@ extension ChooseAppIconView {
   private struct IconChoice: View {
     let icon: AppIcon
     let isSelected: Bool
+    var checkmarkImage: String {
+      isSelected ? "checkmark.circle.fill" : "circle"
+    }
+    
     var body: some View {
       if let iconName = icon.iconName {
-        GroupBox(icon.iconName ?? "Icon") {
-          Image(iconName, label: Text(iconName))
+        GroupBox {
+          HStack {
+            Image(systemName: checkmarkImage)
+              .foregroundStyle(.blue)
+            Text(icon.description)
+            Spacer()
+          }
+          Image(uiImage: icon.preview)
             .resizable()
-            .scaledToFill()
-            .overlay(alignment: .bottomTrailing) {
-              Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                .foregroundStyle(.blue)
-            }
+            .aspectRatio(contentMode: .fit)
         }
       } else {
         EmptyView()

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
@@ -8,67 +8,67 @@
 import SwiftUI
 
 struct ChooseAppIconView: View {
-  @State var viewModel: ChooseAppIconViewModel = .init()
-  
-  private func isSelected(_ icon: AppIcon) -> Bool {
-    return viewModel.selectedAppIcon == icon
-  }
-  
-  private let columns = [
-    GridItem(.flexible(minimum: 30, maximum: 300)),
-    GridItem(.flexible(minimum: 30, maximum: 300))
-  ]
-  var body: some View {
-    Form {
-      Section {
-        HStack {
-          Image(systemName: "apps.iphone")
-            .font(.title)
-          Text("This App Icon will appear on your Home Screen.")
-        }
-      }
-      
-      LazyVGrid(columns: columns) {
-        ForEach(AppIcon.allCases) { icon in
-          IconChoice(icon: icon, isSelected: self.isSelected(icon))
-            .onTapGesture {
-              withAnimation {
-                viewModel.updateAppIcon(to: icon)
-              }
+    @State var viewModel: ChooseAppIconViewModel = .init()
+    
+    private func isSelected(_ icon: AppIcon) -> Bool {
+        return viewModel.selectedAppIcon == icon
+    }
+    
+    private let columns = [
+        GridItem(.flexible(minimum: 30, maximum: 300)),
+        GridItem(.flexible(minimum: 30, maximum: 300))
+    ]
+    var body: some View {
+        Form {
+            Section {
+                HStack {
+                    Image(systemName: "apps.iphone")
+                        .font(.title)
+                    Text("This App Icon will appear on your Home Screen.")
+                }
+            }
+            
+            LazyVGrid(columns: columns) {
+                ForEach(AppIcon.allCases) { icon in
+                    IconChoice(icon: icon, isSelected: self.isSelected(icon))
+                        .onTapGesture {
+                            withAnimation {
+                                viewModel.updateAppIcon(to: icon)
+                            }
+                        }
+                }
             }
         }
-      }
+        .navigationTitle("Choose App Icon")
     }
-    .navigationTitle("Choose App Icon")
-  }
 }
 
 extension ChooseAppIconView {
-  
-  private struct IconChoice: View {
-    let icon: AppIcon
-    let isSelected: Bool
-    var checkmarkImage: String {
-      isSelected ? "checkmark.circle.fill" : "circle"
-    }
     
-    var body: some View {
-      GroupBox {
-        HStack {
-          Image(systemName: checkmarkImage)
-            .foregroundStyle(.blue)
-          Text(icon.description)
-          Spacer()
+    private struct IconChoice: View {
+        let icon: AppIcon
+        let isSelected: Bool
+        var checkmarkImage: String {
+            isSelected ? "checkmark.circle.fill" : "circle"
         }
-        Image(uiImage: icon.preview)
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-          .clipShape(.rect(cornerRadius: 20))
-      }
+        
+        var body: some View {
+            GroupBox {
+                HStack {
+                    Image(systemName: checkmarkImage)
+                        .foregroundStyle(.blue)
+                    Text(icon.description)
+                    Spacer()
+                }
+                Image(uiImage: icon.preview)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .clipShape(.rect(cornerRadius: 20))
+            }
+        }
     }
-  }
 }
 
 #Preview {
-  ChooseAppIconView(viewModel: .init())
+    ChooseAppIconView(viewModel: .init())
 }

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
@@ -14,13 +14,12 @@ struct ChooseAppIconView: View {
     return viewModel.selectedAppIcon == icon
   }
   
+  private let columns = [
+    GridItem(.flexible(minimum: 30, maximum: 300)),
+    GridItem(.flexible(minimum: 30, maximum: 300))
+  ]
   var body: some View {
-    let columns = [
-      GridItem(.flexible(minimum: 30, maximum: 300)),
-      GridItem(.flexible(minimum: 30, maximum: 300))
-    ]
-    
-    return Form {
+    Form {
       Section {
         HStack {
           Image(systemName: "apps.iphone")
@@ -64,6 +63,7 @@ extension ChooseAppIconView {
         Image(uiImage: icon.preview)
           .resizable()
           .aspectRatio(contentMode: .fit)
+          .clipShape(.rect(cornerRadius: 20))
       }
     }
   }

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
@@ -1,0 +1,70 @@
+//
+//  ChooseAppIconView.swift
+//  Basic-Car-Maintenance
+//
+//  Created by Daniel Lyons on 10/11/23.
+//
+
+import SwiftUI
+
+struct ChooseAppIconView: View {
+  @Bindable var viewModel: ChangeAppIconViewModel
+  
+  func isSelected(_ icon: AppIcon) -> Bool {
+    return viewModel.selectedAppIcon == icon
+  }
+  
+  var body: some View {
+    let columns = [
+      GridItem(.flexible(minimum: 30, maximum: 300)),
+      GridItem(.flexible(minimum: 30, maximum: 300))
+    ]
+    
+    return Form {
+      Section {
+        Text("Choose the App Icon that you would like to see on your Home Screen.")
+      }
+      
+      LazyVGrid(columns: columns) {
+        ForEach(AppIcon.allCases) { icon in
+          IconChoice(icon: icon, isSelected: self.isSelected(icon))
+            .onTapGesture {
+              withAnimation {
+                viewModel.selectedAppIcon = icon
+              }
+            }
+        }
+        
+      }
+      
+    }
+    .navigationTitle("Choose App Icon")
+  }
+}
+
+extension ChooseAppIconView {
+  
+  private struct IconChoice: View {
+    let icon: AppIcon
+    let isSelected: Bool
+    var body: some View {
+      if let iconName = icon.iconName {
+        GroupBox(icon.iconName ?? "Icon") {
+          Image(iconName, label: Text(iconName))
+            .resizable()
+            .scaledToFill()
+            .overlay(alignment: .bottomTrailing) {
+              Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(.blue)
+            }
+        }
+      } else {
+        EmptyView()
+      }
+    }
+  }
+}
+
+#Preview {
+  ChooseAppIconView(viewModel: .init())
+}

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ChooseAppIconView: View {
-  @State var viewModel: ChangeAppIconViewModel = .init()
+  @State var viewModel: ChooseAppIconViewModel = .init()
   
   private func isSelected(_ icon: AppIcon) -> Bool {
     return viewModel.selectedAppIcon == icon
@@ -54,20 +54,16 @@ extension ChooseAppIconView {
     }
     
     var body: some View {
-      if let iconName = icon.iconName {
-        GroupBox {
-          HStack {
-            Image(systemName: checkmarkImage)
-              .foregroundStyle(.blue)
-            Text(icon.description)
-            Spacer()
-          }
-          Image(uiImage: icon.preview)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
+      GroupBox {
+        HStack {
+          Image(systemName: checkmarkImage)
+            .foregroundStyle(.blue)
+          Text(icon.description)
+          Spacer()
         }
-      } else {
-        EmptyView()
+        Image(uiImage: icon.preview)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
       }
     }
   }

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -121,7 +121,7 @@ struct SettingsView: View {
                 NavigationLink {
                   ChooseAppIconView(viewModel: viewModel.chooseAppIconViewModel)
                 } label: {
-                  Label("Change App Icon", systemImage: "photo.fill")
+                  Label("Change App Icon", systemImage: "apps.iphone")
                 }
               }
               

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -119,7 +119,7 @@ struct SettingsView: View {
                 }
                 
                 NavigationLink {
-                  ChooseAppIconView(viewModel: viewModel.chooseAppIconViewModel)
+                  ChooseAppIconView(viewModel: ChooseAppIconViewModel())
                 } label: {
                   Label("Change App Icon", systemImage: "apps.iphone")
                 }

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -40,7 +40,7 @@ struct SettingsView: View {
                 Link(destination: URL(string: "https://github.com/mikaelacaron")!) {
                     Text("🦄 Mikaela Caron - Maintainer", comment: "Link to maintainer Github account.")
                 }
-
+                
                 // swiftlint:disable:next line_length
                 Link(destination: URL(string: "https://github.com/mikaelacaron/Basic-Car-Maintenance/issues/new?assignees=&labels=feature+request&projects=&template=feature-request.md&title=FEATURE+-")!) {
                     Label {
@@ -107,24 +107,24 @@ struct SettingsView: View {
                     Text("Vehicles", comment: "Label to display header title.")
                 }
                 
-              Section {
-                NavigationLink {
-                  AuthenticationView(viewModel: viewModel.authenticationViewModel)
-                } label: {
-                  Label {
-                    Text("Profile", comment: "Link to view profile.")
-                  } icon: {
-                    Image(systemName: "person")
-                  }
+                Section {
+                    NavigationLink {
+                        AuthenticationView(viewModel: viewModel.authenticationViewModel)
+                    } label: {
+                        Label {
+                            Text("Profile", comment: "Link to view profile.")
+                        } icon: {
+                            Image(systemName: "person")
+                        }
+                    }
+                    
+                    NavigationLink {
+                        ChooseAppIconView(viewModel: ChooseAppIconViewModel())
+                    } label: {
+                        Label("Change App Icon", systemImage: "apps.iphone")
+                    }
                 }
                 
-                NavigationLink {
-                  ChooseAppIconView(viewModel: ChooseAppIconViewModel())
-                } label: {
-                  Label("Change App Icon", systemImage: "apps.iphone")
-                }
-              }
-              
                 // swiftlint:disable:next line_length
                 Text("Version \(Bundle.main.versionNumber) (\(Bundle.main.buildNumber))", comment: "Label to display version and build number.")
             }

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -107,17 +107,24 @@ struct SettingsView: View {
                     Text("Vehicles", comment: "Label to display header title.")
                 }
                 
-                Section {
-                    NavigationLink {
-                        AuthenticationView(viewModel: viewModel.authenticationViewModel)
-                    } label: {
-                        Label {
-                            Text("Profile", comment: "Link to view profile.")
-                        } icon: {
-                            Image(systemName: "person")
-                        }
-                    }
+              Section {
+                NavigationLink {
+                  AuthenticationView(viewModel: viewModel.authenticationViewModel)
+                } label: {
+                  Label {
+                    Text("Profile", comment: "Link to view profile.")
+                  } icon: {
+                    Image(systemName: "person")
+                  }
                 }
+                
+                NavigationLink {
+                  ChooseAppIconView(viewModel: viewModel.chooseAppIconViewModel)
+                } label: {
+                  Label("Change App Icon", systemImage: "photo.fill")
+                }
+              }
+              
                 // swiftlint:disable:next line_length
                 Text("Version \(Bundle.main.versionNumber) (\(Bundle.main.buildNumber))", comment: "Label to display version and build number.")
             }


### PR DESCRIPTION
# What it Does
* Closes #17
* Describe what your change does
  * Adds a ChooseAppIconView to SettingsView, where the user can pick an alternative app icon. 

# How I Tested
- Run the app. 
- Open Settings Tab
- Tap Change App Icon
- Choose an App Icon
- Go to Home Screen to verify that the App Icon changed. 


# Screenshot
- ![Screenshot 2023-10-11 at 7 07 24 PM](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/72824209/7f73b198-382b-49be-9511-8833b48db2cc)
