### PR TITLE
removed optional text if not empty

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -29,8 +29,10 @@ struct DashboardView: View {
                         
                         Text("\(event.date.formatted(date: .abbreviated, time: .omitted))")
                         
-                        Text(event.notes)
-                            .lineLimit(0)
+                        if !event.notes.isEmpty {
+                            Text(event.notes)
+                                .lineLimit(0)
+                        }
                     }
                     .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                         Button(role: .destructive) {


### PR DESCRIPTION
# What it Does
* Closes #135 
* Adds additional notes only if it is non - empty

# How I Tested
* Add a maintenance card without additional notes

# Screenshot
|With empty space|Without empty space|
|------------------|-----------------------|
|<img src = "https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/32197474/faf8f4d7-f3c2-430d-bbff-0de6eff1e909" width=200>|<img src = "https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/32197474/527682e9-440f-4560-b5cd-92c43749ddce" width=200>|
