### PR TITLE
Fix event deletion

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -111,6 +111,10 @@ class DashboardViewModel {
                 .document(documentId)
                 .delete()
             errorMessage = ""
+            
+            if let eventIndex = events.firstIndex(of: event) {
+                events.remove(at: eventIndex)
+            }
         } catch {
             showErrorAlert.toggle()
             errorMessage = error.localizedDescription


### PR DESCRIPTION
# What it Does
* Closes #63
* When a maintenance event is deleted it is now removed from the local model as well.

# How I Tested
* Run the application
* Tap the (+) button and add a new event
* Swipe the event to the left
* Click the `Delete` button
* The event now disappears from the list

# Screenrecording

https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/2156518/a8c135d4-c596-4854-971d-1383370a2102

