### PR TITLE
Fix:Firebase Warning - added get Vehicles after Vehicle additions

### DIFF
--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -56,11 +56,10 @@ final class SettingsViewModel {
             vehicleToAdd.userID = uid
             
             do {
-                let firestoreRef = try Firestore
+                try Firestore
                     .firestore()
                     .collection("vehicles")
                     .addDocument(from: vehicleToAdd)
-                vehicleToAdd.id = firestoreRef.documentID
                 vehicles.append(vehicleToAdd)
             } catch {
                 throw error

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -157,6 +157,7 @@ struct SettingsView: View {
                     Task {
                         do {
                             try await viewModel.addVehicle(vehicle)
+                            await viewModel.getVehicles()
                             isShowingAddVehicle = false
                         } catch {
                             errorDetails = error


### PR DESCRIPTION
# What it Does
* Closes #159 
* Resolved firebase warning.
* Added get Vehicles call after Vehicle additions

# How I Tested
* Add a list of steps to show the functionality of your feature
For example:
* Run the application
* Navigate to the settings screen
* Add new vehicle
* Removed vehicle