### PR TITLE
Improving Stringly Typed Collection Names

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		023057F22ACFAD79006C5A73 /* EditEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */; };
+		154984AA2AD9CAEE0015594C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154984A92AD9CAEE0015594C /* Constants.swift */; };
 		8014A4CF2AD75928005B51F6 /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4CE2AD75928005B51F6 /* AppIcon.swift */; };
 		8014A4D12AD76034005B51F6 /* ChooseAppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4D02AD76034005B51F6 /* ChooseAppIconView.swift */; };
 		8014A4D32AD77C92005B51F6 /* ChooseAppIconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8014A4D22AD77C92005B51F6 /* ChooseAppIconViewModel.swift */; };
@@ -95,6 +96,7 @@
 
 /* Begin PBXFileReference section */
 		023057F12ACFAD79006C5A73 /* EditEventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEventDetailView.swift; sourceTree = "<group>"; };
+		154984A92AD9CAEE0015594C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		8014A4CE2AD75928005B51F6 /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		8014A4D02AD76034005B51F6 /* ChooseAppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseAppIconView.swift; sourceTree = "<group>"; };
 		8014A4D22AD77C92005B51F6 /* ChooseAppIconViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseAppIconViewModel.swift; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 			isa = PBXGroup;
 			children = (
 				FF755B452A90969D00F49A13 /* Bundle+extension.swift */,
+				154984A92AD9CAEE0015594C /* Constants.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -622,6 +625,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				154984AA2AD9CAEE0015594C /* Constants.swift in Sources */,
 				FFBFE0912A98EFEC000A9BEB /* MaintenanceEvent.swift in Sources */,
 				E58499682ACDDA9A00634660 /* ContributorsProfileView.swift in Sources */,
 				FF755B492A909A0000F49A13 /* AddMaintenanceView.swift in Sources */,

--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -50,7 +50,7 @@ class DashboardViewModel {
             do {
                 try Firestore
                     .firestore()
-                    .collection("maintenance_events")
+                    .collection(FirestoreCollection.maintenanceEvents)
                     .addDocument(from: eventToAdd)
                 
                 events.append(maintenanceEvent)
@@ -67,7 +67,8 @@ class DashboardViewModel {
     func getMaintenanceEvents() async {
         if let uid = authenticationViewModel.user?.uid {
             let db = Firestore.firestore()
-            let docRef = db.collection("maintenance_events").whereField("userID", isEqualTo: uid)
+            let docRef = db.collection(FirestoreCollection.maintenanceEvents)
+                .whereField(FirestoreField.userID, isEqualTo: uid)
             
             let querySnapshot = try? await docRef.getDocuments()
             
@@ -93,7 +94,7 @@ class DashboardViewModel {
             do {
                 try Firestore
                     .firestore()
-                    .collection("maintenance_events")
+                    .collection(FirestoreCollection.maintenanceEvents)
                     .document(id)
                     .setData(from: eventToUpdate)
             } catch {
@@ -112,7 +113,7 @@ class DashboardViewModel {
         do {
             try await Firestore
                 .firestore()
-                .collection("maintenance_events")
+                .collection(FirestoreCollection.maintenanceEvents)
                 .document(documentId)
                 .delete()
             errorMessage = ""

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -1379,6 +1379,7 @@
 
     },
     "This App Icon will appear on your Home Screen." : {
+
     },
     "This is the title" : {
 

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -58,7 +58,7 @@ final class SettingsViewModel {
             do {
                 let firestoreRef = try Firestore
                     .firestore()
-                    .collection("vehicles")
+                    .collection(FirestoreCollection.vehicles)
                     .addDocument(from: vehicleToAdd)
                 vehicleToAdd.id = firestoreRef.documentID
                 vehicles.append(vehicleToAdd)
@@ -72,7 +72,8 @@ final class SettingsViewModel {
     func getVehicles() async {
         if let uid = authenticationViewModel.user?.uid {
             let db = Firestore.firestore()
-            let docRef = db.collection("vehicles").whereField("userID", isEqualTo: uid)
+            let docRef = db.collection(FirestoreCollection.vehicles)
+                .whereField(FirestoreField.userID, isEqualTo: uid)
             
             let querySnapshot = try? await docRef.getDocuments()
             
@@ -102,7 +103,7 @@ final class SettingsViewModel {
         do {
             try await Firestore
                 .firestore()
-                .collection("vehicles")
+                .collection(FirestoreCollection.vehicles)
                 .document(documentId)
                 .delete()
             

--- a/Basic-Car-Maintenance/Shared/Utilities/Constants.swift
+++ b/Basic-Car-Maintenance/Shared/Utilities/Constants.swift
@@ -1,0 +1,17 @@
+//
+//  Constants.swift
+//  Basic-Car-Maintenance
+//
+//  Created by Justin Seal on 10/13/23.
+//
+
+import Foundation
+
+enum FirestoreCollection {
+    static let maintenanceEvents = "maintenance_events"
+    static let vehicles = "vehicles"
+}
+
+enum FirestoreField {
+    static let userID = "userID"
+}


### PR DESCRIPTION
# What it Does
* Closes #118
* Creates enum FirestoreCollection and FirestoreField for stringly-typed Firestore calls. 

# Notes
* Update from previously accidentally closed PR with requested FirestoreField type to separate "userID" calls. 
