### PR TITLE
Added Privacy Policy for Settings

### DIFF
--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -2,6 +2,7 @@
   "sourceLanguage" : "en",
   "strings" : {
     "" : {
+      "extractionState" : "stale",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -1993,6 +1994,7 @@
     },
     "Version %@ (%@)" : {
       "comment" : "Label to display version and build number.",
+      "extractionState" : "stale",
       "localizations" : {
         "cs" : {
           "stringUnit" : {

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -1332,6 +1332,9 @@
         }
       }
     },
+    "Privacy Policy" : {
+
+    },
     "Profile" : {
       "comment" : "Link to view profile.",
       "localizations" : {

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -12,7 +12,6 @@ import Foundation
 @Observable
 final class SettingsViewModel {
     let authenticationViewModel: AuthenticationViewModel
-    let privacyText = "Privacy Policy"
     let privacyURL = URL(string: "https://github.com/mikaelacaron/Basic-Car-Maintenance-Privacy")
 
     var contributors: [Contributor]?

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -12,6 +12,9 @@ import Foundation
 @Observable
 final class SettingsViewModel {
     let authenticationViewModel: AuthenticationViewModel
+    let privacyText = "Privacy Policy"
+    let privacyURL = URL(string: "https://github.com/mikaelacaron/Basic-Car-Maintenance-Privacy")
+
     var contributors: [Contributor]?
     
     var vehicles = [Vehicle]()

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -131,7 +131,7 @@ struct SettingsView: View {
                 
                 // swiftlint:disable:next line_length
                 if let privacyURL = viewModel.privacyURL, !privacyURL.absoluteString.isEmpty {
-                    Link(LocalizedStringKey(stringLiteral: viewModel.privacyText), destination: privacyURL)
+                    Link("Privacy Policy", destination: privacyURL)
                 }
                 Text(LocalizedStringKey(stringLiteral: appVersion), comment: "Label to display version and build number.")
                     .frame(maxWidth: .infinity, alignment: .center)

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -130,6 +130,9 @@ struct SettingsView: View {
                 }
                 
                 // swiftlint:disable:next line_length
+                if let privacyURL = viewModel.privacyURL, !privacyURL.absoluteString.isEmpty {
+                    Link(LocalizedStringKey(stringLiteral: viewModel.privacyText), destination: privacyURL)
+                }
                 Text(LocalizedStringKey(stringLiteral: appVersion), comment: "Label to display version and build number.")
                     .frame(maxWidth: .infinity, alignment: .center)
                     .onLongPressGesture {


### PR DESCRIPTION
# What it Does
* Closes https://github.com/mikaelacaron/Basic-Car-Maintenance/issues/62
* Added Privacy policy link to Settings. When clicked, it opens the page in a user's default browser.

# How I Tested
* Run the application
* Go to Settings screen
* Scroll down to view the app version
* Privacy policy is located above the application version


# Screenshot
<img src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/107453751/a5b00c3e-b16d-4015-8454-dc4a98ff555e" alt="Simulator Screenshot - iPhone 15 Pro - 2023-10-17 at 08 21 17"  width="300">