### PR TITLE
Delete also maintenance events for the deleted vehicle

### DIFF
--- a/Basic-Car-Maintenance/Shared/Models/Vehicle.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Vehicle.swift
@@ -38,4 +38,15 @@ struct Vehicle: Codable, Identifiable, Hashable {
         self.vin = vin
         self.licensePlateNumber = licensePlateNumber
     }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(userID)
+        hasher.combine(name)
+        hasher.combine(make)
+        hasher.combine(model)
+        hasher.combine(year)
+        hasher.combine(color)
+        hasher.combine(vin)
+        hasher.combine(licensePlateNumber)
+    }
 }


### PR DESCRIPTION
# What it Does
* Closes #160 
* This change add the cascade delete for the maintenance events. So when a vehicle gets deleted, all associated event will also be deleted

# How I Tested
* See added Video

# Video
[Bildschirmaufnahme 2023-10-17 um 21.22.33.mov.zip](https://github.com/mikaelacaron/Basic-Car-Maintenance/files/12946029/Bildschirmaufnahme.2023-10-17.um.21.22.33.mov.zip)
