### PR TITLE
Added Firebase analytics screen name(#89)

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/AddMaintenanceView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/AddMaintenanceView.swift
@@ -5,6 +5,7 @@
 //  Created by Mikaela Caron on 8/19/23.
 //
 
+import FirebaseAnalyticsSwift
 import SwiftUI
 
 struct AddMaintenanceView: View {
@@ -67,6 +68,7 @@ struct AddMaintenanceView: View {
                          comment: "Notes text field header")
                 }
             }
+            .analyticsScreen(name: "\(Self.self)")
             .onAppear {
                 if !vehicles.isEmpty {
                     selectedVehicle = vehicles[0]

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -5,6 +5,7 @@
 //  Created by Mikaela Caron on 8/19/23.
 //
 
+import FirebaseAnalyticsSwift
 import SwiftUI
 
 struct DashboardView: View {
@@ -62,6 +63,7 @@ struct DashboardView: View {
                 }
                 .listStyle(.inset)
             }
+            .analyticsScreen(name: "\(Self.self)")
             .searchable(text: $viewModel.searchText)
             .overlay {
                 if viewModel.events.isEmpty {

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/EditEventDetailView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/EditEventDetailView.swift
@@ -5,6 +5,7 @@
 //  Created by Aaron Wilson on 10/5/23.
 //
 
+import FirebaseAnalyticsSwift
 import SwiftUI
 
 struct EditMaintenanceEventView: View {
@@ -50,6 +51,7 @@ struct EditMaintenanceEventView: View {
                     Text("Notes")
                 }
             }
+            .analyticsScreen(name: "\(Self.self)")
             .onAppear {
                 guard let selectedEvent = selectedEvent else { return }
                 setMaintenanceEventValues(event: selectedEvent)

--- a/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
@@ -5,6 +5,7 @@
 //  Created by Mikaela Caron on 8/25/23.
 //
 
+import FirebaseAnalyticsSwift
 import SwiftUI
 
 struct AddVehicleView: View {
@@ -67,6 +68,7 @@ struct AddVehicleView: View {
                     Text("License Plate Number")
                 }
             }
+            .analyticsScreen(name: "\(Self.self)")
             .toolbar {
                 ToolbarItem {
                     Button {

--- a/Basic-Car-Maintenance/Shared/Settings/Views/AuthenticationView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/AuthenticationView.swift
@@ -6,6 +6,7 @@
 //
 
 import AuthenticationServices
+import FirebaseAnalyticsSwift
 import SwiftUI
 
 struct AuthenticationView: View {
@@ -56,6 +57,7 @@ struct AuthenticationView: View {
                 }
             }
         }
+        .analyticsScreen(name: "\(Self.self)")
     }
 }
 

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ContributorsListView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ContributorsListView.swift
@@ -5,6 +5,7 @@
 //  Created by Yashraj jadhav on 01/10/23.
 //
 
+import FirebaseAnalyticsSwift
 import SwiftUI
 
 struct ContributorsListView: View {
@@ -24,6 +25,7 @@ struct ContributorsListView: View {
                 ProgressView()
             }
         }
+        .analyticsScreen(name: "\(Self.self)")
         .task {
             Task {
                 await viewModel.getContributors()

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -5,6 +5,7 @@
 //  Created by Mikaela Caron on 8/19/23.
 //
 
+import FirebaseAnalyticsSwift
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -163,6 +164,7 @@ struct SettingsView: View {
                             .animation(.linear(duration: 0.2), value: copiedAppVersion)
                     }
             }
+            .analyticsScreen(name: "\(Self.self)")
             .navigationDestination(isPresented: $isShowingAddVehicle) {
                 AddVehicleView() { vehicle in
                     Task {


### PR DESCRIPTION
# What it Does
* Closes #89 
* Logs screen name events in Firebase analytics

# How I Tested
* Enabled debug logging by setting the application argument -FIRAnalyticsDebugEnabled
* Run the application
* Navigate to required screens to verify if the analytics event gets logged in console  

# Screenshot
<img width="1109" alt="Screenshot 2023-10-20 at 2 01 59 AM" src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/46681753/0ef225c9-3c3f-4fe4-8bbf-327cff1b83e0">
<img width="1109" alt="Screenshot 2023-10-20 at 2 03 31 AM" src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/46681753/babf8b38-d1cd-4d69-8da0-23117e618317">
