### PR TITLE
Changed the order of edit and filter on Dashboard

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -88,16 +88,6 @@ struct DashboardView: View {
             }
             .toolbar {
                 ToolbarItemGroup(placement: .primaryAction) {
-                    Button {
-                        viewModel.isShowingAddMaintenanceEvent = true
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .accessibilityShowsLargeContentViewer {
-                        Label("Add", systemImage: "plus")
-
-                    }
-                    
                     Menu {
                         Picker(selection: $viewModel.sortOption) {
                             ForEach(DashboardViewModel.SortOption.allCases) { option in
@@ -112,6 +102,15 @@ struct DashboardView: View {
                     }
                     .accessibilityShowsLargeContentViewer {
                         Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+
+                    }
+                    Button {
+                        viewModel.isShowingAddMaintenanceEvent = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityShowsLargeContentViewer {
+                        Label("Add", systemImage: "plus")
 
                     }
                 }


### PR DESCRIPTION
# What it Does
* Closes #144
* switches the order of toolbar items

# How I Tested
* Add a list of steps to show the functionality of your feature
For example:
* Run the application
* check the Dashboard screen and see filter is before the + 


# Notes
* Nothing as such 