### PR TITLE
Fix `DashboardView` no events on 1st load

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -114,16 +114,17 @@ struct DashboardView: View {
                     }
                 }
             }
-            .task {
-                await viewModel.getMaintenanceEvents()
-                await viewModel.getVehicles()
-            }
             .sheet(isPresented: $isShowingAddView) {
                 makeAddMaintenanceView()
             }
         }
         .onChange(of: scenePhase) { _, newScenePhase in
             guard case .active = newScenePhase else { return }
+            
+            Task {
+                await viewModel.getMaintenanceEvents()
+                await viewModel.getVehicles()
+            }
             
             guard let action = actionService.action,
                   action == .newMaintenance

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -146,9 +146,6 @@ struct DashboardView: View {
     private func makeAddMaintenanceView() -> some View {
         AddMaintenanceView(vehicles: viewModel.vehicles) { event in
             viewModel.addEvent(event)
-            Task {
-                await viewModel.getMaintenanceEvents()
-            }
         }
         .alert("An Error Occurred", isPresented: $viewModel.showAddErrorAlert) {
             Button("OK", role: .cancel) {}


### PR DESCRIPTION
# What it Does
* Closes #210 
* This PR will call the closure to get the events & vehicles when the app is in the foreground, not when the view appear


# How I Tested
* Build then run the app in the simulator

# Notes
* I'm not entirely sure if this is best practice

# Screenshot
![RocketSim_Recording_iPhone_15_2023-10-28_22 18 34](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/82783173/34e16578-3e52-437c-a757-b76bd0570bf3)
