### PR TITLE
Update readme with unit test status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Welcome to my open source app! It is ready for contributors for [Hacktoberfest](
 ![GitHub contributors](https://img.shields.io/github/contributors/mikaelacaron/Basic-Car-Maintenance)
 [![first-timers-only](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://www.firsttimersonly.com/)
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/mikaelacaron/Basic-Car-Maintenance/swiftlint.yml)
+![Unit Tests Workflow Status Badge](https://github.com/mikaelacaron/Basic-Car-Maintenance/actions/workflows/unit-tests.yml/badge.svg)
 
 * Read the [Code of Conduct](https://github.com/mikaelacaron/Basic-Car-Maintenance/blob/main/CODE_OF_CONDUCT.md)
 * Read the [CONTRIBUTING.md](https://github.com/mikaelacaron/Basic-Car-Maintenance/blob/main/CONTRIBUTING.md) guidelines


### PR DESCRIPTION
# What it Does
* Closes #241 
* Adds a [github status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) for the unit tests workflow

# How I Tested
* Update the readme and viewed in preview mode

# Notes
* The casing of `Unit Tests` does not seem to be editable at the moment unlike the other badges.

# Screenshot
<img width="819" alt="Screenshot 2023-10-29 at 1 14 24 PM" src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/103429618/7a7f703c-8aa3-45be-8159-54e65b6597d1">
