### PR TITLE
235 add ci passing badge

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches:
       - dev
+  push:
+    branches:
+      - main
+      - dev
   
 # Limit only the latest workflow created to run
 concurrency:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Welcome to my open source app! It is ready for contributors for [Hacktoberfest](
 ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/mikaelacaron/Basic-Car-Maintenance/dev?logo=github)
 ![GitHub contributors](https://img.shields.io/github/contributors/mikaelacaron/Basic-Car-Maintenance)
 [![first-timers-only](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://www.firsttimersonly.com/)
-![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/mikaelacaron/Basic-Car-Maintenance/swiftlint.yml)
+[![Unit Tests](https://github.com/mikaelacaron/Basic-Car-Maintenance/actions/workflows/unit-tests.yml/badge.svg?event=push)](https://github.com/mikaelacaron/Basic-Car-Maintenance/actions/workflows/unit-tests.yml)
 
 * Read the [Code of Conduct](https://github.com/mikaelacaron/Basic-Car-Maintenance/blob/main/CODE_OF_CONDUCT.md)
 * Read the [CONTRIBUTING.md](https://github.com/mikaelacaron/Basic-Car-Maintenance/blob/main/CONTRIBUTING.md) guidelines


### PR DESCRIPTION
# What it Does
* Closes  #235 
* Replaces static "build passing" badge with the "Unit Test" CI status one
* Added a push trigger to the "Unit Test" CI, so the badge can reference the status of the branch instead of the last PR

# How I Tested
* Open the repository README.md
* The README should show the "Unit Tests | passing" badge
* Clicking on the badge
* Should show the CI runs history

# Notes
To avoid making the badge reference the last CI run (that could be from a PR), I had to add a trigger for pushes in the `dev` and `main` branches and add the `event=push` parameter to the badge to make sure it shows the status of the build for the current state of that branch ([see the documentation](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-event-parameter)).

I used the actions badge as instructed, but the style does not match the existing ones. Shields.io provides a badge for workflow status that should work the same way:

GitHub:
[![Unit Tests](https://github.com/mikaelacaron/Basic-Car-Maintenance/actions/workflows/unit-tests.yml/badge.svg?event=push)](https://github.com/mikaelacaron/Basic-Car-Maintenance/actions/workflows/unit-tests.yml)

Shields.io
[![Unit Tests](https://img.shields.io/github/actions/workflow/status/mikaelacaron/Basic-Car-Maintenance/unit-tests.yml?event=push&logo=github&label=Unit%20Tests)](https://github.com/mikaelacaron/Basic-Car-Maintenance/actions/workflows/unit-tests.yml)

Ps: There is no status because there are no CI runs for `push`s yet.

# Screenshot
<img width="881" alt="image" src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/12241478/81b8e086-f462-4654-a8a9-0a7995b027bc">
