### PR TITLE
Swipe Action to Delete OdometerReading

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/xcshareddata/xcschemes/Basic-Car-Maintenance-WidgetExtension.xcscheme
+++ b/Basic-Car-Maintenance.xcodeproj/xcshareddata/xcschemes/Basic-Car-Maintenance-WidgetExtension.xcscheme
@@ -90,6 +90,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Basic-Car-Maintenance.xcodeproj/xcshareddata/xcschemes/Basic-Car-Maintenance-WidgetExtension.xcscheme
+++ b/Basic-Car-Maintenance.xcodeproj/xcshareddata/xcschemes/Basic-Car-Maintenance-WidgetExtension.xcscheme
@@ -90,7 +90,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
-      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Basic-Car-Maintenance/Shared/Odometer/ViewModels/OdometerViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/ViewModels/OdometerViewModel.swift
@@ -36,6 +36,28 @@ class OdometerViewModel {
         }
     }
     
+    func deleteReading(_ reading: OdometerReading) async {
+        guard let documentId = reading.id else {
+            fatalError("Reading Entry has no document ID.")
+        }
+        
+        do {
+            try await Firestore
+                .firestore()
+                .collection(FirestoreCollection.odometerReadings)
+                .document(documentId)
+                .delete()
+            errorMessage = ""
+            
+            if let eventIndex = readings.firstIndex(of: reading) {
+                readings.remove(at: eventIndex)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+            showAddErrorAlert = true
+        }
+    }
+        
     func getOdometerReadings() async {
         if let uid = authenticationViewModel.user?.uid {
             let db = Firestore.firestore()

--- a/Basic-Car-Maintenance/Shared/Odometer/ViewModels/OdometerViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/ViewModels/OdometerViewModel.swift
@@ -41,20 +41,14 @@ class OdometerViewModel {
             fatalError("Reading Entry has no document ID.")
         }
         
-        do {
-            try await Firestore
-                .firestore()
-                .collection(FirestoreCollection.odometerReadings)
-                .document(documentId)
-                .delete()
-            errorMessage = ""
-            
-            if let eventIndex = readings.firstIndex(of: reading) {
-                readings.remove(at: eventIndex)
-            }
-        } catch {
-            errorMessage = error.localizedDescription
-            showAddErrorAlert = true
+        try? await Firestore
+            .firestore()
+            .collection(FirestoreCollection.odometerReadings)
+            .document(documentId)
+            .delete()
+        
+        if let eventIndex = readings.firstIndex(of: reading) {
+            readings.remove(at: eventIndex)
         }
     }
         

--- a/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
@@ -29,6 +29,15 @@ struct OdometerView: View {
                         
                         Text("\(reading.date.formatted(date: .abbreviated, time: .omitted))")
                     }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            Task {
+                                await viewModel.deleteReading(reading)
+                            }
+                        } label: {
+                            Image(systemName: SFSymbol.trash)
+                        }
+                    }
                 }
                 .listStyle(.inset)
             }


### PR DESCRIPTION
# What it Does
* Closes #212 
Allows the user to delete a OdometerReading from the list on OdometerView

# How I Tested
* Run the application on simulator on iPhone SE and iPhone 15 under iOS 17
* Went to settings and created a new Vehicle 
* Switched to Odometer Tab
* Added a new Reading
* Swiped from right to left on the new entry
* Tapped the delete button / icon

# Notes
* Followed the same coding pattern under `MaintenanceEvent` on the ` DashboardView` 

# Screenshot

https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/2402695/b7d2ed2b-607b-4abc-8c74-a77ff9d6c25a

