### PR TITLE
Change Label Icons on SettingsView to use Scalable Images

### DIFF
--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -14,6 +14,8 @@ struct SettingsView: View {
     @Environment(ActionService.self) var actionService
     @Environment(\.scenePhase) var scenePhase
     @Environment(\.colorScheme) var colorScheme
+   
+    @ScaledMetric(relativeTo: .largeTitle) var iconDimension = 20.0
     
     @State private var viewModel: SettingsViewModel
     @State private var isShowingAddVehicle = false
@@ -42,7 +44,7 @@ struct SettingsView: View {
                         } icon: {
                             Image("github-logo")
                                 .resizable()
-                                .frame(width: 20, height: 20)
+                                .frame(width: iconDimension, height: iconDimension)
                         }
                     }
                     .popoverTip(ContributionTip(), arrowEdge: .bottom)
@@ -58,7 +60,7 @@ struct SettingsView: View {
                         } icon: {
                             Image(systemName: SFSymbol.document)
                                 .resizable()
-                                .frame(width: 20, height: 20)
+                                .frame(width: iconDimension, height: iconDimension)
                         }
                     }
                     // swiftlint:disable:next line_length
@@ -68,7 +70,7 @@ struct SettingsView: View {
                         } icon: {
                             Image(systemName: SFSymbol.ladybug)
                                 .resizable()
-                                .frame(width: 20, height: 20)
+                                .frame(width: iconDimension, height: iconDimension)
                         }
                     }
                     


### PR DESCRIPTION
# What it Does
* Closes #103
* Scales the images in Label icons within the SettingsView in parallel with changes in Dynamic Text
* Uses an @ScaledMetric property wrapper, based on the .largeTitle font, to define the image frame dimensions 

# How I Tested
* Ran the original and modified code in parallel in two simulators
* changed the dynamic type size in both simulators using cmd-opt-plus & cmd-opt-minus
* visually confirmed that the modified code scaled the images up and down in line with changes to dynamic text

# Notes
Scaling the text to higher font sizes highlights the layout discrepancy between the Labels for most items in the List and the use of a single Text view for the maintainer row.  Consider changes this to a Label too?

# Screenshot
![BMC-103](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/12803226/61a5054d-2e72-47dd-8f72-e56da5bcc5c8)