### PR TITLE
Vehicle List Improvement #213

### DIFF
--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -94,13 +94,18 @@ struct SettingsView: View {
                             
                             Text(vehicle.model)
 
-                            Text(vehicle.year ?? "")
-
-                            Text(vehicle.color ?? "")
-
-                            Text(vehicle.vin ?? "")
-
-                            Text(vehicle.licensePlateNumber ?? "")
+                            if let year = vehicle.year, !year.isEmpty {
+                                Text(year)
+                            }
+                            if let color = vehicle.color, !color.isEmpty {
+                                Text(color)
+                            }
+                            if let vin = vehicle.vin, !vin.isEmpty {
+                                Text(vin)
+                            }
+                            if let licensePlateNumber = vehicle.licensePlateNumber, !licensePlateNumber.isEmpty {
+                                Text(licensePlateNumber)
+                            }
                         }
                         .swipeActions {
                             Button(role: .destructive) {


### PR DESCRIPTION
# What it Does
 - Closes #213 
 - Allows empty fields to not be displayed in the settings view
 
# How I Tested
- Run the app
- Go to the 'SettingsView' tab

# Notes
 - Added 'if let' conditionals to the "non-required" input information such as - year, color, VIN, and license plate number

# Screenshot
![Simulator Screenshot - iPhone 15 - 2023-11-03 at 05 33 33](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/79613749/cd994bc7-a197-4452-9a4d-b0532db65351)

![Screenshot 2023-10-31 at 5 42 18 AM](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/79613749/3ee2e46f-20ef-422a-a18a-2be43dcb5ea4)