### PR TITLE
217 fix docc tutorial deployment

### DIFF
--- a/Basic-Car-Maintenance/Documentation.docc/Documentation.md
+++ b/Basic-Car-Maintenance/Documentation.docc/Documentation.md
@@ -8,9 +8,10 @@ This app is open source for [Hacktoberfest 2023](https://hacktoberfest.com/)!
 
 Use this app to gain experience getting started in open source for iOS and macOS development using Swift and SwiftUI.
 
-More documentation to be added soon!
+Explore contribution essentials with the <doc:Tutorial-Table-of-Contents> Tutorial.
 
-Explore the essentials with the <doc:Tutorial-Table-of-Contents> Tutorial!
+
+More documentation to be added soon!
 
 ## New Icon
 The app icon contains a Car, Tools, and Gear

--- a/Basic-Car-Maintenance/Documentation.docc/Documentation.md
+++ b/Basic-Car-Maintenance/Documentation.docc/Documentation.md
@@ -10,7 +10,6 @@ Use this app to gain experience getting started in open source for iOS and macOS
 
 Explore contribution essentials with the <doc:Tutorial-Table-of-Contents> Tutorial.
 
-
 More documentation to be added soon!
 
 ## New Icon

--- a/Basic-Car-Maintenance/Documentation.docc/Documentation.md
+++ b/Basic-Car-Maintenance/Documentation.docc/Documentation.md
@@ -10,6 +10,8 @@ Use this app to gain experience getting started in open source for iOS and macOS
 
 More documentation to be added soon!
 
+Explore the essentials with the <doc:Tutorial-Table-of-Contents> Tutorial!
+
 ## New Icon
 The app icon contains a Car, Tools, and Gear
 


### PR DESCRIPTION
# What it Does
* Closes #217 
* Inside the Basic-Car-Maintenance documentation Article, there is now a link to the DocC Getting Started Tutorials

# How I Tested
Part 1: Create the Link for the Tutorials
* Inside the Basic-Car-Maintenance documentation Article: add a link to the Getting started tutorial using `<doc:Tutorial-Table-of-Contents>` command. (Note that the hyperlink comes out as "Getting Started")
* Go to Product -> Build Documentation
* Verify Tutorial is linked from within the document article
* Commit/Push changes

Part 2: Check site hosting is still working
* Update the build script and remove the repo name reference, so that `--hosting-base-path "Basic-Car-Maintenance"` becomes `--hosting-base-path ""`
* Run the `build-docc.sh` script
* Run the following python command to host the documentation locally: `/usr/bin/python3 -m http.server -d .docs`
* In new private browsing safari window, enter `localhost:8000` into the URL bar
* The documentation should now appear as it would when it is hosted from GitHub actions
* Dismiss local changes as they were for testing only

# Notes
* Documents and Tutorials are separated when statically hosting docc archives (at least when using the `docc process-archive transform-for-static-hosting` command. The build script at the bottom has the command `'<script>window.location.href += "documentation/basic_car_maintenance"</script>' > .docs/index.html` which means start at the Documentation side of the DocC hosting. 
* Could not find a way to host it similar to how Xcode Builds it with both Documentation and Tutorials in the Side Pane, so adding a link to the tutorials files seemed like the quickest option to get tutorials hosted. WWDC 22 video "What's new in Swift DocC" appeared to show loading directly from the archive (without static hosting command) on GitHub pages, but I could not get this to work.

# Screenshot

The following show the documentation loaded via "local host" in private browsing in Safari (so that browser doesn't accidentally cache previous attempts at loading the page).

![test_tutorial_1](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/6628293/90fc81ce-9851-40e8-b475-975c56750e57)
![test_tutorial_2](https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/6628293/dae210be-5805-4518-b9f2-a683f58110df)


