### PR TITLE
Fix `FirebaseAnalyticsModifier`

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/xcshareddata/xcschemes/Basic-Car-Maintenance.xcscheme
+++ b/Basic-Car-Maintenance.xcodeproj/xcshareddata/xcschemes/Basic-Car-Maintenance.xcscheme
@@ -75,6 +75,10 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
+            argument = "-FIRAnalyticsDebugEnabled"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-FIRDebugEnabled"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/AddMaintenanceView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/AddMaintenanceView.swift
@@ -67,7 +67,7 @@ struct AddMaintenanceView: View {
                          comment: "Notes text field header")
                 }
             }
-            .analyticsView()
+            .analyticsView("\(Self.self)")
             .navigationTitle(Text("Add Maintenance",
                                   comment: "Nagivation title for Add Maintenance view"))
             .toolbar {

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -69,7 +69,7 @@ struct DashboardView: View {
                 }
                 .listStyle(.inset)
             }
-            .analyticsView()
+            .analyticsView("\(Self.self)")
             .searchable(text: $viewModel.searchText)
             .overlay {
                 if viewModel.isLoading {

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/EditEventDetailView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/EditEventDetailView.swift
@@ -50,7 +50,7 @@ struct EditMaintenanceEventView: View {
                     Text("Notes")
                 }
             }
-            .analyticsView()
+            .analyticsView("\(Self.self)")
             .onAppear {
                 guard let selectedEvent = selectedEvent else { return }
                 setMaintenanceEventValues(event: selectedEvent)

--- a/Basic-Car-Maintenance/Shared/Info.plist
+++ b/Basic-Car-Maintenance/Shared/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAutomaticScreenReportingEnabled</key>
+	<false/>
 	<key>UIApplicationShortcutItems</key>
 	<array>
 		<dict>

--- a/Basic-Car-Maintenance/Shared/Odometer/Views/AddOdometerReadingView.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/Views/AddOdometerReadingView.swift
@@ -84,6 +84,7 @@ struct AddOdometerReadingView: View {
                 }
             }
         }
+        .analyticsView("\(Self.self)")
     }
 }
 

--- a/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
@@ -66,7 +66,7 @@ struct OdometerView: View {
                 await viewModel.getVehicles()
             }
         }
-        .analyticsView()
+        .analyticsView("\(Self.self)")
     }
     
     private func makeAddOdometerView() -> some View {

--- a/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/AddVehicleView.swift
@@ -72,7 +72,7 @@ struct AddVehicleView: View {
                     Text("License Plate Number")
                 }
             }
-            .analyticsView()
+            .analyticsView("\(Self.self)")
             .toolbar {
                 ToolbarItem {
                     Button {

--- a/Basic-Car-Maintenance/Shared/Settings/Views/AuthenticationView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/AuthenticationView.swift
@@ -56,7 +56,7 @@ struct AuthenticationView: View {
                 }
             }
         }
-        .analyticsView()
+        .analyticsView("\(Self.self)")
     }
 }
 

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ChooseAppIconView.swift
@@ -40,6 +40,7 @@ struct ChooseAppIconView: View {
             }
         }
         .navigationTitle("Choose App Icon")
+        .analyticsView("\(Self.self)")
     }
 }
 

--- a/Basic-Car-Maintenance/Shared/Settings/Views/ContributorsListView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/ContributorsListView.swift
@@ -24,7 +24,7 @@ struct ContributorsListView: View {
                 ProgressView()
             }
         }
-        .analyticsView()
+        .analyticsView("\(Self.self)")
         .task {
             Task {
                 await viewModel.getContributors()

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -183,7 +183,7 @@ struct SettingsView: View {
                             .animation(.linear(duration: 0.2), value: copiedAppVersion)
                     }
             }
-            .analyticsView()
+            .analyticsView("\(Self.self)")
             .navigationDestination(isPresented: $isShowingAddVehicle) {
                 AddVehicleView() { vehicle in
                     Task {

--- a/Basic-Car-Maintenance/Shared/Utilities/FirebaseAnalytics+Extension.swift
+++ b/Basic-Car-Maintenance/Shared/Utilities/FirebaseAnalytics+Extension.swift
@@ -8,15 +8,18 @@
 import SwiftUI
 import FirebaseAnalyticsSwift
 
-struct FireBaseAnalyticsModifier: ViewModifier {
+struct FirebaseAnalyticsModifier: ViewModifier {
+    
+    let screenName: String
+    
     func body(content: Content) -> some View {
         content
-            .analyticsScreen(name: "\(Self.self)")
+            .analyticsScreen(name: screenName)
     }
 }
 
 extension View {
-    func analyticsView() -> some View {
-        modifier(FireBaseAnalyticsModifier())
+    func analyticsView(_ name: String) -> some View {
+        modifier(FirebaseAnalyticsModifier(screenName: name))
     }
 }


### PR DESCRIPTION
# What it Does
* It was logging the `FirebaseAnalyticsModifier` rather than logging the screen name because the `Self.self` was placed in the modifier, rather than being called in each view

# How I Tested
* Viewed results in Firebase

# Notes
* N/A