### PR TITLE
fix: DashboardView events Aren't Loading on the First Load

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -11,12 +11,12 @@ struct DashboardView: View {
     @Environment(ActionService.self) var actionService
     @Environment(\.scenePhase) var scenePhase
     @State private var isShowingAddView = false
-    @Bindable private var viewModel: DashboardViewModel
+    @State private var viewModel: DashboardViewModel
     @State private var isShowingEditView = false
     @State private var selectedMaintenanceEvent: MaintenanceEvent?
     
     init(userUID: String?) {
-        viewModel = DashboardViewModel(userUID: userUID)
+        self._viewModel = State(initialValue: DashboardViewModel(userUID: userUID))
     }
     
     private var eventDateFormat: DateFormatter = {

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -16,7 +16,7 @@ struct DashboardView: View {
     @State private var selectedMaintenanceEvent: MaintenanceEvent?
     
     init(userUID: String?) {
-        self._viewModel = State(initialValue: DashboardViewModel(userUID: userUID))
+        _viewModel = State(initialValue: DashboardViewModel(userUID: userUID))
     }
     
     private var eventDateFormat: DateFormatter = {


### PR DESCRIPTION
# What it Does
* Closes #210
* Correctly shows maintenance events on first load of the application.

# How I Tested
* Run the application with Dashboard tab open.
* 2 of my maintenance events that I created loaded right away. First loading indicator was shown, later events themselves.
* Switched to Odometer tab and back to Dashboard, loaded once again correctly.
* Run the application with Odometer tab open.
* Switched to Dashboard tab, events loaded correctly.

# Notes
* I have a couple of notes here:
* 1. @Bindable macro was switched to @State because State is enough and correct one to use in this case as @State makes property both mutable and observable. 

Later I had an issue that initializer would give me `Variable 'self.viewModel' used before being initialized` error, if I wrote the code as 
```
    init(userUID: String?) {
        viewModel = DashboardViewModel(userUID: userUID)
    }
```

To be frank, this was a strange error for compiler to give in my opinion, so I read on the topic a bit and decided to use underscored version of the property - the actual underlying property that is accessed through projected value. In order to set it I need to use `State(initialValue: )` that allows me to make initial value of the state equal to `DashboardViewModel` provided with `userUID`.

* 2. Second note I would like to add is that on each tab change `getMaintenanceEvents()` or `getOdometerReadings()` are fired constantly, if data is not changed that results in overhead requests to Firebase.

# Screenshot
* Screen recording of the fixed feature attached.
https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/18750749/252807b6-1b3e-4587-9b95-12025607d357
