### PR TITLE
fix: Prevent Users From Deleting All Vehicles

### DIFF
--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -3950,22 +3950,8 @@
         }
       }
     },
-    "The last vehicle can't be deleted" : {
-      "comment" : "Alert message preventing users from deleting their last vehicle",
-      "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Последний автомобиль удалить невозможно."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Son araç silinemez"
-          }
-        }
-      }
+    "The last vehicle can't be deleted. Please add a new vehicle before removing this one." : {
+      "comment" : "Alert message preventing users from deleting their last vehicle"
     },
     "The title of the event" : {
       "comment" : "Maintenance event title text field label placeholder",

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -731,6 +731,22 @@
         }
       }
     },
+    "Can't Delete Last Vehicle" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невозможно удалить последний автомобиль"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son Araç Silinemiyor"
+          }
+        }
+      }
+    },
     "Cancel" : {
       "localizations" : {
         "be" : {
@@ -3934,6 +3950,23 @@
         }
       }
     },
+    "The last vehicle can't be deleted" : {
+      "comment" : "Alert message preventing users from deleting their last vehicle",
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последний автомобиль удалить невозможно."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son araç silinemez"
+          }
+        }
+      }
+    },
     "The title of the event" : {
       "comment" : "Maintenance event title text field label placeholder",
       "localizations" : {
@@ -4413,7 +4446,14 @@
       }
     },
     "Update Vehicle Info" : {
-
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Araç Bilgilerini Güncelle"
+          }
+        }
+      }
     },
     "Vehicle" : {
       "comment" : "Maintenance event vehicle picker header",

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -250,7 +250,7 @@ struct SettingsView: View {
                     showDeleteVehicleAlert = false
                 }
             } message: {
-                Text("The last vehicle can't be deleted", comment: "Alert message preventing users from deleting their last vehicle")
+                Text("The last vehicle can't be deleted. Please add a new vehicle before removing this one.", comment: "Alert message preventing users from deleting their last vehicle")
             }
             .navigationTitle(Text("Settings", comment: "Label to display settings."))
             .task {

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @State private var viewModel: SettingsViewModel
     @State private var isShowingAddVehicle = false
     @State private var showDeleteVehicleError = false
+    @State private var showDeleteVehicleAlert = false
     @State private var showAddVehicleError = false
     @State private var errorDetails: Error?
     @State private var copiedAppVersion: Bool = false
@@ -117,7 +118,11 @@ struct SettingsView: View {
                             Button(role: .destructive) {
                                 Task {
                                     do {
-                                        try await viewModel.deleteVehicle(vehicle)
+                                        if viewModel.vehicles.count > 1 {
+                                            try await viewModel.deleteVehicle(vehicle)
+                                        } else {
+                                            showDeleteVehicleAlert = true
+                                        }
                                     } catch {
                                         errorDetails = error
                                         showDeleteVehicleError = true
@@ -239,6 +244,13 @@ struct SettingsView: View {
                     Text("Failed To Delete Vehicle. Unknown Error.",
                          comment: "Label to display error details.")
                 }
+            }
+            .alert("Can't Delete Last Vehicle", isPresented: $showDeleteVehicleAlert) {
+                Button("OK", role: .cancel) {
+                    showDeleteVehicleAlert = false
+                }
+            } message: {
+                Text("The last vehicle can't be deleted", comment: "Alert message preventing users from deleting their last vehicle")
             }
             .navigationTitle(Text("Settings", comment: "Label to display settings."))
             .task {


### PR DESCRIPTION
# What it Does
* Closes #202
* I have added control to check the number of active vehicles user has, and if user has only 1 vehicle left, they cannot delete the last vehicle. If they press delete or swipe they are greeted with an alert.

# How I Tested
* Run the application, open Settings tab
* Deleted vehicle using swipe gesture.
* Was greeted with an Alert.
* Deleted vehicle pressing on delete swipe action button.
* Was greeted with an Alert.

# Notes
* Delete functionality itself wasn't implemented yet. I had already 2 vehicles added. Because I couldn't delete them from Firebase, I upped the control counter to 2 for local tests. I pushed the code with control counter set to 1.

# Screenshot
* Adding scree

https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/18750749/005af7ad-499a-46aa-a531-1ecf0dc78aaf

n recording:
