### PR TITLE
feature: Use NavigationSplitView rather than TabView for iPad #6

### DIFF
--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -3686,6 +3686,16 @@
         }
       }
     },
+    "Sidebar" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Боковая панель"
+          }
+        }
+      }
+    },
     "Sign Out" : {
       "localizations" : {
         "be" : {
@@ -4297,6 +4307,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Назва обслуговування"
+          }
+        }
+      }
+    },
+    "Unexpected error occured." : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Произошла ошибка."
           }
         }
       }

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -731,6 +731,9 @@
         }
       }
     },
+    "Basic Car" : {
+
+    },
     "Can't Delete Last Vehicle" : {
       "localizations" : {
         "ru" : {
@@ -3687,6 +3690,7 @@
       }
     },
     "Sidebar" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ru" : {
           "stringUnit" : {
@@ -4312,6 +4316,7 @@
       }
     },
     "Unexpected error occured." : {
+      "extractionState" : "stale",
       "localizations" : {
         "ru" : {
           "stringUnit" : {

--- a/Basic-Car-Maintenance/Shared/MainView/Views/MainTabView.swift
+++ b/Basic-Car-Maintenance/Shared/MainView/Views/MainTabView.swift
@@ -17,9 +17,7 @@ enum TabSelection: Int, Identifiable, CaseIterable {
 }
 
 extension TabSelection {
-    // you can make TabSelection :String
-    // insteaf of :Int too and remove label
-    var label: String {
+    var label: LocalizedStringKey {
         switch self {
         case .dashboard:
             return "Dashboard"
@@ -60,15 +58,15 @@ struct MainTabView: View {
     
     var body: some View {
         Group {
-#if os(iOS)
+            #if os(iOS)
             if UIDevice.current.userInterfaceIdiom == .pad {
                 navigationSplitView()
             } else {
                 tabView()
             }
-#else
+            #else
             navigationSplitView()
-#endif
+            #endif
         }
         .sheet(item: $viewModel.alert) { alert in
             AlertView(alert: alert)
@@ -104,12 +102,6 @@ struct MainTabView: View {
         let acknowledgedAlert = AcknowledgedAlert(id: id)
         context.insert(acknowledgedAlert)
     }
-}
-
-extension MainTabView {
-    private func tabItem(for selection: TabSelection) -> some View {
-        Label(selection.label, systemImage: selection.image)
-    }
     
     /// Save screen content for specific selection
     /// - Parameter selection: tab selection enum value
@@ -124,41 +116,33 @@ extension MainTabView {
             SettingsView(authenticationViewModel: authenticationViewModel)
         }
     }
-    
-    /// Returns last column of NavigationSplitView - detail content
-    @ViewBuilder
-    private func splitViewDetailContent() -> some View {
-        if let tabSelection = selectedTabId {
-            selectionContent(for: tabSelection)
-                .tag(tabSelection)
-        } else {
-            Text("Unexpected error occured.")
-        }
-    }
-    
-    /// Returns NavigationSplitView navigation
-    /// primarily used on iPad and Mac devices
+        
+    /// Primarily used on iPad and Mac devices
+    /// - Returns: `NavigationSplitView` navigation
     @ViewBuilder
     private func navigationSplitView() -> some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             List(TabSelection.allCases, selection: $selectedTabId) { tabSelection in
                 Label(tabSelection.label, systemImage: tabSelection.image)
             }
-            .navigationTitle("Sidebar")
+            .navigationTitle("Basic Car")
         } detail: {
-            splitViewDetailContent()
+            if let tabSelection = selectedTabId {
+                selectionContent(for: tabSelection)
+                    .tag(tabSelection)
+            }
         }
     }
     
-    /// Returns TabView navigation
-    /// primarily used on iPhone devices
+    /// Primarily used on iPhone devices
+    /// - Returns: `TabView` navigation
     @ViewBuilder func tabView() -> some View {
         TabView(selection: $selectedTab) {
             ForEach(TabSelection.allCases) { tabSelection in
                 selectionContent(for: tabSelection)
                     .tag(tabSelection)
                     .tabItem {
-                        tabItem(for: tabSelection)
+                        Label(tabSelection.label, systemImage: tabSelection.image)
                     }
             }
         }

--- a/Basic-Car-Maintenance/Shared/MainView/Views/MainTabView.swift
+++ b/Basic-Car-Maintenance/Shared/MainView/Views/MainTabView.swift
@@ -56,6 +56,10 @@ struct MainTabView: View {
     @State var authenticationViewModel = AuthenticationViewModel()
     @State var viewModel = MainTabViewModel()
     
+    init() {
+        _selectedTabId = State(initialValue: selectedTab)
+    }
+    
     var body: some View {
         Group {
             #if os(iOS)
@@ -93,6 +97,9 @@ struct MainTabView: View {
         .onChange(of: viewModel.alert) { _, newValue in
             guard let id = newValue?.id else { return }
             saveNewAlert(id)
+        }
+        .onChange(of: selectedTabId ?? TabSelection.dashboard) { _, newValue in
+            selectedTab = newValue
         }
     }
     


### PR DESCRIPTION
# What it Does
* Closes #6 
* I have added `NavigationSplitView` logic into `MainTabView` struct. This addition is mutating only iPad version right now (completely works) and should affect MacOS version as well in the future (MacOS isn't building as of now). iPhone proceeds with `TabView` navigation. I have also refactored the code - added extension to hold `@ViewBuilder` views for better reusability and more readable code - because at the end of the day `TabView` and `NavigationSplitView` use the same content.

# How I Tested
* I have tested this new feature on Previews first and later on Simulators.
* Tested on iPhone 15 Pro Max - 17.0.1
* Tested on iPad Pro 12.9 inch - 17.0.1
* iPad shows `NavigationSplitView` navigation - can be toggled to be shown/hidden.
* iPhone shows `TabView` navigation.

# Notes
* There is a comment I have left in the code that TabSelection enum can be changed to conform to String rather than Int. If needed can be easily swiped out, currently is left as is.

# Screenshot
* Two screen recordings - iPad and iPhone.

https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/18750749/7eda95ac-3913-426c-b3a7-eb210ba943b9


https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/18750749/d78bad15-0f16-486e-bf8c-3a3612f3d982

