### PR TITLE
Fix to change "App Language" to be "System Language" instead of `Polish`

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/xcshareddata/xcschemes/Basic-Car-Maintenance.xcscheme
+++ b/Basic-Car-Maintenance.xcodeproj/xcshareddata/xcschemes/Basic-Car-Maintenance.xcscheme
@@ -57,7 +57,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = "pl"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
# What it Does
* Closes #281
* Addresses https://github.com/mikaelacaron/Basic-Car-Maintenance/issues/7
* Reported bug https://github.com/mikaelacaron/Basic-Car-Maintenance/issues/281 by @rbennum
* Building on my original PR https://github.com/mikaelacaron/Basic-Car-Maintenance/pull/280
* This new PR is with fix to change 'App Language' to be 'System Language' instead of 'Polish'

# How I Tested
* Run the application in simulator with language set to System Language
* Checked screens that show proper English translation

# Screenshots
<img width="401" alt="140-fix-default-localization-polish-2" src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/53284922/3ee06978-475b-47c6-89dc-51b728798fa1">


<img width="801" alt="280-fix-default-localization-polish-2" src="https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/53284922/ece63a30-7ee1-465d-8e09-02482c2675ef">
