### PR TITLE
Add voice-over and voice control supports to the Dashboard page.

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -45,6 +45,7 @@ struct DashboardView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
+                    .accessibilityElement(children: .combine)
                     .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                         Button(role: .destructive) {
                             Task {


### PR DESCRIPTION
# What it Does
* Closes #51 
* Adds voice-over and voice control supports on the Dashboard page.

# How I Tested
* Run voice control and voice-over from the Accessibility menu on Settings.
* Open the app to the Dashboard page.
* Add and delete events on your own.

# Notes
* There is a bug I can't handle right now when I try to fill the bottom part of the text field in any views using Voice Control but the first responder is not activating.
* Also I'm still learning how to navigate swipeable cells using the Voice-Over feature so it just went untested for now.

# Screenshot

https://github.com/mikaelacaron/Basic-Car-Maintenance/assets/8705838/a4e5e8f6-d5ae-4ac6-8304-99ec9b019b0c