### PR TITLE
fix: infinite loading on Dashboard

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -75,23 +75,23 @@ class DashboardViewModel {
 
         if let userUID = userUID {
             let db = Firestore.firestore()
-            
-            let docRef = db.collectionGroup(FirestoreCollection.maintenanceEvents)
-                .whereField(FirestoreField.userID, isEqualTo: userUID)
-            
-            let querySnapshot = try? await docRef.getDocuments()
-            
-            var events = [MaintenanceEvent]()
-            
-            if let querySnapshot {
+            do {
+                let docRef = db.collectionGroup(FirestoreCollection.maintenanceEvents)
+                    .whereField(FirestoreField.userID, isEqualTo: userUID)
+                
+                let querySnapshot = try await docRef.getDocuments()
+                
+                var events = [MaintenanceEvent]()
+                
                 for document in querySnapshot.documents {
                     if let event = try? document.data(as: MaintenanceEvent.self) {
                         events.append(event)
                     }
                 }
-                
                 self.isLoading = false
                 self.events = events
+            } catch {
+                self.isLoading = false
             }
         }
     }


### PR DESCRIPTION
# What it Does
* Closes #288 
* Fetching snapshot from firebase can throw error so putting the code inside do catch and handling the case of error by setting loading state to false

# How I Tested
* Run the app
* The DashboardView loads with a ProgressView for a finite time.

# Screenshot
Now screen loads finitely in case of any error too.
https://github.com/user-attachments/assets/fdc035ac-11bd-438a-b8e3-3297ae50c39e

