### PR TITLE
Convert ContribtorTests to use SwiftTesting

### DIFF
--- a/Basic-Car-Maintenance-Tests/Shared/Models/ContributorTests.swift
+++ b/Basic-Car-Maintenance-Tests/Shared/Models/ContributorTests.swift
@@ -5,63 +5,65 @@
 //  Created by Drag0ndust on 07.10.23.
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import Basic_Car_Maintenance
 
-final class ContributorTests: XCTestCase {
-    private var jsonDecoder: JSONDecoder!
-    private var jsonEncoder: JSONEncoder!
-    private let testContributorJson = """
-{
-    "login": "Drag0ndust",
-    "id": 12915108,
-    "node_id": "MDQ6VXNlcjEyOTE1MTA4",
-    "avatar_url": "https://avatars.githubusercontent.com/u/12915108?v=4",
-    "url": "https://api.github.com/users/Drag0ndust",
-    "html_url": "https://github.com/Drag0ndust",
-    "contributions": 0
-}
-"""
-
-    override func setUpWithError() throws {
-        jsonDecoder = JSONDecoder()
+struct ContributorTests {
+    private let jsonDecoder = {
+        let jsonDecoder = JSONDecoder()
         jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
-
-        jsonEncoder = JSONEncoder()
+        return jsonDecoder
+    }()
+    
+    private let jsonEncoder = {
+        let jsonEncoder = JSONEncoder()
         jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
+        return jsonEncoder
+    }()
+    
+    @Test()
+    func contributorDecoding() throws {
+        let testContributorJson = """
+    {
+        "login": "Drag0ndust",
+        "id": 12915108,
+        "node_id": "MDQ6VXNlcjEyOTE1MTA4",
+        "avatar_url": "https://avatars.githubusercontent.com/u/12915108?v=4",
+        "url": "https://api.github.com/users/Drag0ndust",
+        "html_url": "https://github.com/Drag0ndust",
+        "contributions": 0
     }
-
-    func testContributorDecoding() throws {
-        guard let data = testContributorJson.data(using: .utf8) else {
-            XCTFail("Can't decode JSON string")
-            return
-        }
-
+"""
+        let data = try #require(testContributorJson.data(using: .utf8))
         let sut = try jsonDecoder.decode(Contributor.self, from: data)
-
-        XCTAssertEqual(sut.login, "Drag0ndust")
-        XCTAssertEqual(sut.id, 12915108)
-        XCTAssertEqual(sut.nodeID, "MDQ6VXNlcjEyOTE1MTA4")
-        XCTAssertEqual(sut.avatarURL, "https://avatars.githubusercontent.com/u/12915108?v=4")
-        XCTAssertEqual(sut.url, "https://api.github.com/users/Drag0ndust")
-        XCTAssertEqual(sut.htmlURL, "https://github.com/Drag0ndust")
-        XCTAssertEqual(sut.contributions, 0)
+        
+        #expect(sut.login == "Drag0ndust")
+        #expect(sut.id == 12915108)
+        #expect(sut.nodeID == "MDQ6VXNlcjEyOTE1MTA4")
+        #expect(sut.avatarURL == "https://avatars.githubusercontent.com/u/12915108?v=4")
+        #expect(sut.url == "https://api.github.com/users/Drag0ndust")
+        #expect(sut.htmlURL == "https://github.com/Drag0ndust")
+        #expect(sut.contributions == 0)
     }
     
-    func testContributorEncoding() throws {
-        let contributor = Contributor(login: "Drag0ndust",
-                                      id: 12915108,
-                                      nodeID: "MDQ6VXNlcjEyOTE1MTA4",
-                                      avatarURL: "https://avatars.githubusercontent.com/u/12915108?v=4",
-                                      url: "https://api.github.com/users/Drag0ndust",
-                                      htmlURL: "https://github.com/Drag0ndust",
-                                      contributions: 0)
+    @Test()
+    func contributorEncoding() throws {
+        let contributor = Contributor(
+            login: "Drag0ndust",
+            id: 12915108,
+            nodeID: "MDQ6VXNlcjEyOTE1MTA4",
+            avatarURL: "https://avatars.githubusercontent.com/u/12915108?v=4",
+            url: "https://api.github.com/users/Drag0ndust",
+            htmlURL: "https://github.com/Drag0ndust",
+            contributions: 0
+        )
         
         let contributorData = try jsonEncoder.encode(contributor)
         
-       // now decode it again and check if the objects are equal
+        // now decode it again and check if the objects are equal
         let decodedContributor = try jsonDecoder.decode(Contributor.self, from: contributorData)
         
-        XCTAssertEqual(contributor, decodedContributor)
+        #expect(contributor == decodedContributor)
     }
 }


### PR DESCRIPTION
# What it Does
* Closes #307
Convert `ContributorTests` to use the new Swift Testing framwork instead of XCTest


# How I Tested
Run `ContributorTests` from Xcode 

