### PR TITLE
Vehicle Display in settings

### DIFF
--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -89,16 +89,6 @@
         }
       }
     },
-    "%@: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@: %2$@"
-          }
-        }
-      }
-    },
     "%lld %@" : {
       "localizations" : {
         "de" : {
@@ -1130,6 +1120,9 @@
         }
       }
     },
+    "Color: %@" : {
+
+    },
     "Continue" : {
 
     },
@@ -1676,6 +1669,9 @@
           }
         }
       }
+    },
+    "Display Name: %@" : {
+
     },
     "Distance" : {
       "localizations" : {
@@ -3587,6 +3583,9 @@
       }
     },
     "Open Source" : {
+
+    },
+    "Plate: %@" : {
 
     },
     "Preferred units" : {
@@ -5794,6 +5793,9 @@
           }
         }
       }
+    },
+    "VIN: %@" : {
+
     },
     "Welcome 🥳" : {
 

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -1670,9 +1670,6 @@
         }
       }
     },
-    "Display Name: %@" : {
-
-    },
     "Distance" : {
       "localizations" : {
         "de" : {

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -89,6 +89,16 @@
         }
       }
     },
+    "%@: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: %2$@"
+          }
+        }
+      }
+    },
     "%lld %@" : {
       "localizations" : {
         "de" : {

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -91,19 +91,21 @@ struct SettingsView: View {
                 Section {
                     ForEach(viewModel.vehicles) { vehicle in
                         VStack(alignment: .leading, spacing: 2) {
-                            HStack {
-                                if let year = vehicle.year, !year.isEmpty {
-                                    Text(year)
-                                }
-                                
-                                Text(vehicle.make)
-                                
-                                Text(vehicle.model)
-                            }
-                            .fontWeight(.bold)
-                            .font(.headline)
+                            Text("Display Name: \(vehicle.name)")
+                                .fontWeight(.bold)
+                                .font(.headline)
                             
                             Group {
+                                HStack {
+                                    if let year = vehicle.year, !year.isEmpty {
+                                        Text(year)
+                                    }
+                                    
+                                    Text(vehicle.make)
+                                    
+                                    Text(vehicle.model)
+                                }
+                                
                                 if let licensePlateNumber =
                                     vehicle.licensePlateNumber,
                                    !licensePlateNumber.isEmpty {
@@ -116,9 +118,7 @@ struct SettingsView: View {
                                 
                                 if let color = vehicle.color, !color.isEmpty {
                                     Text("Color: \(color)")
-                                }
-                                
-                                Text("Display Name: \(vehicle.name)")
+                                } 
                             }
                             .font(.callout)
                             .foregroundStyle(.secondary)

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -29,6 +29,15 @@ struct SettingsView: View {
     @State private var isShowingEditVehicleView = false
     
     private let appVersion = "Version \(Bundle.main.versionNumber) (\(Bundle.main.buildNumber))"
+
+    private func vehicleDetails(for vehicle: Vehicle) -> [(label: String, value: String?)] {
+        [
+            ("Plate", vehicle.licensePlateNumber),
+            ("VIN", vehicle.vin),
+            ("Color", vehicle.color),
+            ("Display Name", vehicle.name)
+        ]
+    }
     
     init(authenticationViewModel: AuthenticationViewModel) {
         let settingsViewModel = SettingsViewModel(authenticationViewModel: authenticationViewModel)
@@ -90,29 +99,26 @@ struct SettingsView: View {
                 
                 Section {
                     ForEach(viewModel.vehicles) { vehicle in
-                        VStack(alignment: .leading) {
-                            Text(vehicle.name)
-                                .font(.headline)
-                            
-                            Text(vehicle.make)
-                            
-                            Text(vehicle.model)
-                            
-                            if let year = vehicle.year, !year.isEmpty {
-                                Text(year)
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 4) {
+                                ForEach(
+                                    [
+                                        vehicle.year,
+                                        vehicle.make,
+                                        vehicle.model
+                                    ].compactMap { $0 }, id: \.self) { info in
+                                    Text(info)
+                                        .fontWeight(.bold)
+                                        .font(.headline)
+                                }
                             }
                             
-                            if let color = vehicle.color, !color.isEmpty {
-                                Text(color)
-                            }
-                            
-                            if let vin = vehicle.vin, !vin.isEmpty {
-                                Text(vin)
-                            }
-                            
-                            if let licensePlateNumber = vehicle.licensePlateNumber,
-                               !licensePlateNumber.isEmpty {
-                                Text(licensePlateNumber)
+                            ForEach(vehicleDetails(for: vehicle), id: \.label) { detail in
+                                if let value = detail.value, !value.isEmpty {
+                                    Text("\(detail.label): \(value)")
+                                        .font(.callout)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
                         }
                         .swipeActions {

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -91,7 +91,7 @@ struct SettingsView: View {
                 Section {
                     ForEach(viewModel.vehicles) { vehicle in
                         VStack(alignment: .leading, spacing: 2) {
-                            Text("Display Name: \(vehicle.name)")
+                            Text("\(vehicle.name)")
                                 .fontWeight(.bold)
                                 .font(.headline)
                             

--- a/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/SettingsView.swift
@@ -29,15 +29,6 @@ struct SettingsView: View {
     @State private var isShowingEditVehicleView = false
     
     private let appVersion = "Version \(Bundle.main.versionNumber) (\(Bundle.main.buildNumber))"
-
-    private func vehicleDetails(for vehicle: Vehicle) -> [(label: String, value: String?)] {
-        [
-            ("Plate", vehicle.licensePlateNumber),
-            ("VIN", vehicle.vin),
-            ("Color", vehicle.color),
-            ("Display Name", vehicle.name)
-        ]
-    }
     
     init(authenticationViewModel: AuthenticationViewModel) {
         let settingsViewModel = SettingsViewModel(authenticationViewModel: authenticationViewModel)
@@ -99,27 +90,38 @@ struct SettingsView: View {
                 
                 Section {
                     ForEach(viewModel.vehicles) { vehicle in
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 4) {
-                                ForEach(
-                                    [
-                                        vehicle.year,
-                                        vehicle.make,
-                                        vehicle.model
-                                    ].compactMap { $0 }, id: \.self) { info in
-                                    Text(info)
-                                        .fontWeight(.bold)
-                                        .font(.headline)
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                if let year = vehicle.year, !year.isEmpty {
+                                    Text(year)
                                 }
+                                
+                                Text(vehicle.make)
+                                
+                                Text(vehicle.model)
                             }
+                            .fontWeight(.bold)
+                            .font(.headline)
                             
-                            ForEach(vehicleDetails(for: vehicle), id: \.label) { detail in
-                                if let value = detail.value, !value.isEmpty {
-                                    Text("\(detail.label): \(value)")
-                                        .font(.callout)
-                                        .foregroundStyle(.secondary)
+                            Group {
+                                if let licensePlateNumber =
+                                    vehicle.licensePlateNumber,
+                                   !licensePlateNumber.isEmpty {
+                                    Text("Plate: \(licensePlateNumber)")
                                 }
+                                
+                                if let vin = vehicle.vin, !vin.isEmpty {
+                                    Text("VIN: \(vin)")
+                                }
+                                
+                                if let color = vehicle.color, !color.isEmpty {
+                                    Text("Color: \(color)")
+                                }
+                                
+                                Text("Display Name: \(vehicle.name)")
                             }
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
                         }
                         .swipeActions {
                             Button(role: .destructive) {


### PR DESCRIPTION
# What it Does
* Closes #332 
* Changed how the vehicle details are displayed in the settings screen, to match proposition made by @rramirez-dev

# How I Tested
* Run the application in Simulator (iPhone 15 Pro, iOS 17.5), set language to 'English'
* Click tab 'Settings'
* Click row 'Add Vehicle' in 'VEHICLES' section
* Add information in NAME, MAKE, MODEL, YEAR, COLOR, VIN, LICENSE PLATE NUMBER section
* Click 'Add' button
* See the screen in 'Screenshot' section, where are displayed vehicle details in changed format

# Notes
* Changes in text also works when User will want to change vehicle details when vehicle details already exist

# Screenshot
<img src="https://github.com/user-attachments/assets/b0a99c1c-04ee-417b-8bd1-42aad011872c" height="550">