### PR TITLE
BUG - ExportOptionsView alert when vehicle has no events to export

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
@@ -14,6 +14,7 @@ struct ExportOptionsView: View {
     @State private var selectedVehicle: Vehicle?
     @State private var isShowingThumbnail = false
     @State private var pdfDoc: PDFDocument?
+    @State private var showingErrorAlert = false
     
     private let dataSource: [Vehicle: [MaintenanceEvent]]
     
@@ -43,12 +44,17 @@ struct ExportOptionsView: View {
                     Button("Export") { 
                         if let selectedVehicle,
                            let events = self.dataSource[selectedVehicle] {
-                            let pdfGenerator = CarMaintenancePDFGenerator(
-                                vehicleName: selectedVehicle.name,
-                                events: events
-                            )
-                            self.pdfDoc = pdfGenerator.generatePDF() 
-                            isShowingThumbnail = true
+                            
+                            if !events.isEmpty {
+                                let pdfGenerator = CarMaintenancePDFGenerator(
+                                    vehicleName: selectedVehicle.name,
+                                    events: events
+                                )
+                                self.pdfDoc = pdfGenerator.generatePDF() 
+                                isShowingThumbnail = true
+                            } else {
+                                showingErrorAlert = true
+                            }
                         }
                     }
                 }
@@ -73,6 +79,17 @@ struct ExportOptionsView: View {
                     }
                     .presentationDetents([.medium])
                 }
+            }
+            .alert(Text("Failed to export events",
+                        comment: "Title for alert shown when there are no events to export for a vehicle"),
+                   isPresented: $showingErrorAlert) {
+                Button {
+                    showingErrorAlert = false
+                } label: {
+                    Text("OK", comment: "Label to dismiss alert")
+                }
+            } message: {
+                Text("No events to export for this vehicle").padding()
             }
         }
     }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
@@ -80,17 +80,20 @@ struct ExportOptionsView: View {
                     .presentationDetents([.medium])
                 }
             }
-            .alert(Text("Failed to export events",
-                        comment: "Title for alert shown when there are no events to export for a vehicle"),
-                   isPresented: $showingErrorAlert) {
-                Button {
-                    showingErrorAlert = false
-                } label: {
-                    Text("OK", comment: "Label to dismiss alert")
+            .alert(
+                Text(
+                    "Failed to Export Events",
+                    comment: "Title for alert shown when there are no events to export for a vehicle"
+                ),
+                isPresented: $showingErrorAlert) {
+                    Button {
+                        showingErrorAlert = false
+                    } label: {
+                        Text("OK", comment: "Label to dismiss alert")
+                    }
+                } message: {
+                    Text("No events to export for this vehicle.")
                 }
-            } message: {
-                Text("No events to export for this vehicle").padding()
-            }
         }
     }
 }

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -2571,6 +2571,9 @@
         }
       }
     },
+    "Failed to export events" : {
+      "comment" : "Title for alert shown when there are no events to export for a vehicle."
+    },
     "Filter" : {
       "comment" : "Label for filtering on Dashboard view",
       "localizations" : {
@@ -3436,6 +3439,9 @@
           }
         }
       }
+    },
+    "No events to export for this vehicle." : {
+
     },
     "No Name" : {
       "extractionState" : "manual"

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -2571,8 +2571,8 @@
         }
       }
     },
-    "Failed to export events" : {
-      "comment" : "Title for alert shown when there are no events to export for a vehicle."
+    "Failed to Export Events" : {
+      "comment" : "Title for alert shown when there are no events to export for a vehicle"
     },
     "Filter" : {
       "comment" : "Label for filtering on Dashboard view",


### PR DESCRIPTION
# What it Does
* Closes #363 
* This PR shows an alert over ExportOptionsView to inform the user that they can't export events for the selected vehicle because there are no events available to export.

# How I Tested
* Add a list of steps to show the functionality of your feature
For example:
* Run the application
* Add two vehicle in the Settings tab
* Add at least one event to only one of the vehicles in the Dashboard tab
* Tap the export button in the Dashboard tab
* Scroll the picker to the vehicle without events and tap "Export"
* See the alert

# Notes
* No notes

# Screenshot
* https://github.com/user-attachments/assets/6246ff80-07cd-4334-9a86-b8557cb9dccf