### PR TITLE
Update Firebase to v11

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -9,13 +9,10 @@
 /* Begin PBXBuildFile section */
 		FF153AFF2B07C3E000D0BA30 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = FF153AFE2B07C3E000D0BA30 /* FirebaseCrashlytics */; };
 		FF4E82BE2AD39863004949AF /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = FF4E82BD2AD39863004949AF /* FirebaseRemoteConfig */; };
-		FF4E82C02AD39863004949AF /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = FF4E82BF2AD39863004949AF /* FirebaseRemoteConfigSwift */; };
 		FF4E82C22AD39863004949AF /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = FF4E82C12AD39863004949AF /* FirebaseStorage */; };
 		FFC8CDA72AA3867A00D129A6 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = FFC8CDA62AA3867A00D129A6 /* FirebaseAnalytics */; };
-		FFC8CDA92AA3867A00D129A6 /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = FFC8CDA82AA3867A00D129A6 /* FirebaseAnalyticsSwift */; };
 		FFC8CDAB2AA3867A00D129A6 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = FFC8CDAA2AA3867A00D129A6 /* FirebaseAuth */; };
 		FFC8CDAD2AA3867A00D129A6 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = FFC8CDAC2AA3867A00D129A6 /* FirebaseFirestore */; };
-		FFC8CDAF2AA3867A00D129A6 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = FFC8CDAE2AA3867A00D129A6 /* FirebaseFirestoreSwift */; };
 		FFC8CDB32AA4226900D129A6 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFC8CDB22AA4226900D129A6 /* AdSupport.framework */; };
 		FFDADF7F2ACD35A100DDEF79 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFDADF7E2ACD35A100DDEF79 /* WidgetKit.framework */; };
 		FFDADF812ACD35A100DDEF79 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFDADF802ACD35A100DDEF79 /* SwiftUI.framework */; };
@@ -104,12 +101,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				FF4E82BE2AD39863004949AF /* FirebaseRemoteConfig in Frameworks */,
-				FFC8CDAF2AA3867A00D129A6 /* FirebaseFirestoreSwift in Frameworks */,
-				FFC8CDA92AA3867A00D129A6 /* FirebaseAnalyticsSwift in Frameworks */,
 				FFC8CDAD2AA3867A00D129A6 /* FirebaseFirestore in Frameworks */,
 				FFC8CDAB2AA3867A00D129A6 /* FirebaseAuth in Frameworks */,
 				FFC8CDA72AA3867A00D129A6 /* FirebaseAnalytics in Frameworks */,
-				FF4E82C02AD39863004949AF /* FirebaseRemoteConfigSwift in Frameworks */,
 				FF153AFF2B07C3E000D0BA30 /* FirebaseCrashlytics in Frameworks */,
 				FF4E82C22AD39863004949AF /* FirebaseStorage in Frameworks */,
 				FFC8CDB32AA4226900D129A6 /* AdSupport.framework in Frameworks */,
@@ -203,12 +197,9 @@
 			name = "Basic-Car-Maintenance";
 			packageProductDependencies = (
 				FFC8CDA62AA3867A00D129A6 /* FirebaseAnalytics */,
-				FFC8CDA82AA3867A00D129A6 /* FirebaseAnalyticsSwift */,
 				FFC8CDAA2AA3867A00D129A6 /* FirebaseAuth */,
 				FFC8CDAC2AA3867A00D129A6 /* FirebaseFirestore */,
-				FFC8CDAE2AA3867A00D129A6 /* FirebaseFirestoreSwift */,
 				FF4E82BD2AD39863004949AF /* FirebaseRemoteConfig */,
-				FF4E82BF2AD39863004949AF /* FirebaseRemoteConfigSwift */,
 				FF4E82C12AD39863004949AF /* FirebaseStorage */,
 				FF153AFE2B07C3E000D0BA30 /* FirebaseCrashlytics */,
 			);
@@ -857,7 +848,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.14.0;
+				minimumVersion = 11.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -878,11 +869,6 @@
 			package = FFC8CDA52AA3867A00D129A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseRemoteConfig;
 		};
-		FF4E82BF2AD39863004949AF /* FirebaseRemoteConfigSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FFC8CDA52AA3867A00D129A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseRemoteConfigSwift;
-		};
 		FF4E82C12AD39863004949AF /* FirebaseStorage */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FFC8CDA52AA3867A00D129A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
@@ -893,11 +879,6 @@
 			package = FFC8CDA52AA3867A00D129A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalytics;
 		};
-		FFC8CDA82AA3867A00D129A6 /* FirebaseAnalyticsSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FFC8CDA52AA3867A00D129A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalyticsSwift;
-		};
 		FFC8CDAA2AA3867A00D129A6 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FFC8CDA52AA3867A00D129A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
@@ -907,11 +888,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FFC8CDA52AA3867A00D129A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFirestore;
-		};
-		FFC8CDAE2AA3867A00D129A6 /* FirebaseFirestoreSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FFC8CDA52AA3867A00D129A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseFirestoreSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Basic-Car-Maintenance.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Basic-Car-Maintenance.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
-        "version" : "10.19.2"
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
-        "version" : "10.29.0"
+        "revision" : "8328630971a8fdd8072b36bb22bef732eb15e1f0",
+        "version" : "11.4.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
-        "version" : "10.28.0"
+        "revision" : "4f234bcbdae841d7015258fbbf8e7743a39b8200",
+        "version" : "11.4.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
-        "version" : "9.4.0"
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
-        "version" : "7.13.3"
+        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
+        "version" : "8.0.2"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
-        "version" : "1.62.2"
+        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+        "version" : "1.65.1"
       }
     },
     {

--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -7,7 +7,6 @@
 //
 
 import FirebaseFirestore
-import FirebaseFirestoreSwift
 import Foundation
 
 @Observable

--- a/Basic-Car-Maintenance/Shared/MainView/ViewModels/MainTabViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/MainView/ViewModels/MainTabViewModel.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import FirebaseFirestore
-import FirebaseFirestoreSwift
 
 @Observable
 class MainTabViewModel {

--- a/Basic-Car-Maintenance/Shared/Models/AlertItem.swift
+++ b/Basic-Car-Maintenance/Shared/Models/AlertItem.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import FirebaseFirestoreSwift
+import FirebaseFirestore
 import SwiftData
 
 struct AlertItem: Codable, Identifiable {

--- a/Basic-Car-Maintenance/Shared/Models/MaintenanceEvent.swift
+++ b/Basic-Car-Maintenance/Shared/Models/MaintenanceEvent.swift
@@ -6,7 +6,7 @@
 //  See LICENSE for license information.
 //
 
-import FirebaseFirestoreSwift
+import FirebaseFirestore
 import Foundation
 
 struct MaintenanceEvent: Codable, Identifiable, Hashable {

--- a/Basic-Car-Maintenance/Shared/Models/OdometerReading.swift
+++ b/Basic-Car-Maintenance/Shared/Models/OdometerReading.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import FirebaseFirestoreSwift
+import FirebaseFirestore
 
 struct OdometerReading: Codable, Identifiable, Hashable {
     @DocumentID var id: String?

--- a/Basic-Car-Maintenance/Shared/Models/Vehicle.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Vehicle.swift
@@ -6,7 +6,7 @@
 //  See LICENSE for license information.
 //
 
-import FirebaseFirestoreSwift
+import FirebaseFirestore
 import Foundation
 
 struct Vehicle: Codable, Identifiable, Hashable {

--- a/Basic-Car-Maintenance/Shared/Odometer/ViewModels/OdometerViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/ViewModels/OdometerViewModel.swift
@@ -7,7 +7,6 @@
 //
 
 import FirebaseFirestore
-import FirebaseFirestoreSwift
 import Foundation
 
 @Observable

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -7,7 +7,6 @@
 //
 
 import FirebaseFirestore
-import FirebaseFirestoreSwift
 import Foundation
 
 @Observable

--- a/Basic-Car-Maintenance/Shared/Utilities/FirebaseAnalytics+Extension.swift
+++ b/Basic-Car-Maintenance/Shared/Utilities/FirebaseAnalytics+Extension.swift
@@ -7,7 +7,7 @@
 //
 
 import SwiftUI
-import FirebaseAnalyticsSwift
+import FirebaseAnalytics
 
 struct FirebaseAnalyticsModifier: ViewModifier {
     


### PR DESCRIPTION
# What it Does
* Updates Firebase with SPM to v11+
* Remove deprecated libraries
   * FirebaseRemoteConfigSwift
   * FirebaseAnalyticsSwift
   * FirebaseFirestoreSwift

# How I Tested
N/A

# Notes
There seems to be more output in the console related to Firebase, could be an issue with the SDK, but not sure yet

# Screenshot
N/A