### PR TITLE
IMPROVE: updated fetchNewestAlert function to be async

### DIFF
--- a/Basic-Car-Maintenance/Shared/MainView/ViewModels/MainTabViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/MainView/ViewModels/MainTabViewModel.swift
@@ -29,9 +29,8 @@ class MainTabViewModel {
         
         do {
           let snapshot = try await query.getDocuments()
-          let documents = snapshot.documents
             
-            let newAlert = documents
+            let newAlert = snapshot.documents
                 .compactMap {
                     do {
                         return try $0.data(as: AlertItem.self)
@@ -51,7 +50,5 @@ class MainTabViewModel {
         } catch {
           print("Error getting documents: \(error)")
         }
-        
-
     }
 }

--- a/Basic-Car-Maintenance/Shared/MainView/ViewModels/MainTabViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/MainView/ViewModels/MainTabViewModel.swift
@@ -14,7 +14,7 @@ class MainTabViewModel {
     @MainActor var alert: AlertItem?
     
     /// Update the UI once a new alert is sent
-    func fetchNewestAlert(ignoring acknowledgedAlerts: [String]) {
+    func fetchNewestAlert(ignoring acknowledgedAlerts: [String]) async {
         
         var query = Firestore
             .firestore()
@@ -27,12 +27,9 @@ class MainTabViewModel {
                 .whereField(FirestoreField.id, notIn: acknowledgedAlerts)
         }
         
-        query.getDocuments { [weak self] snapshot, error in
-            guard let self,
-                  error == nil,
-                  let documents = snapshot?.documents else {
-                return
-            }
+        do {
+          let snapshot = try await query.getDocuments()
+          let documents = snapshot.documents
             
             let newAlert = documents
                 .compactMap {
@@ -50,6 +47,11 @@ class MainTabViewModel {
                     self.alert = newAlert
                 }
             }
+
+        } catch {
+          print("Error getting documents: \(error)")
         }
+        
+
     }
 }

--- a/Basic-Car-Maintenance/Shared/MainView/Views/MainTabView.swift
+++ b/Basic-Car-Maintenance/Shared/MainView/Views/MainTabView.swift
@@ -93,7 +93,9 @@ struct MainTabView: View {
             }
         }
         .onAppear {
-            viewModel.fetchNewestAlert(ignoring: acknowledgedAlerts.map(\.id))
+            Task { @MainActor in
+                 await viewModel.fetchNewestAlert(ignoring: acknowledgedAlerts.map(\.id))
+             }
         }
         .onChange(of: viewModel.alert) { _, newValue in
             guard let id = newValue?.id else { return }


### PR DESCRIPTION
# What it Does
* Closes #359
* The change updates the `fetchNewestAlert` function to use async instead of a closure

# How I Tested
* Manually input an alert into the firebase collection
* Rerun the application

# Notes
* This function could also be updated to throw errors and handle them.

# Screenshot
<img width="869" alt="Screenshot 2024-11-06 at 16 52 22" src="https://github.com/user-attachments/assets/a6c7c04d-b0c6-43cd-8ce0-b2d512de40e6">
