### PR TITLE
Implement CSV export of maintenance events

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/CSVEncoder.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/CSVEncoder.swift
@@ -19,24 +19,13 @@ struct CSVColumn<Record> {
    
     private(set) var attribute: (Record) -> CSVEncodable
     
-    init(
-        _ header: String,
-        attribute: @escaping (Record) -> CSVEncodable
-    ) {
+    init( _ header: String, attribute: @escaping (Record) -> CSVEncodable) {
         self.header = header
         self.attribute = attribute
     }
-}
-
-extension CSVColumn {
-    init<T: CSVEncodable> (
-        _ header: String,
-        _ keyPath: KeyPath<Record, T>
-    ) {
-        self.init(
-            header,
-            attribute: { $0[keyPath: keyPath] }
-        )
+    
+    init<T: CSVEncodable> (_ header: String, _ keyPath: KeyPath<Record, T>) {
+        self.init(header, attribute: { $0[keyPath: keyPath] })
     }
 }
 
@@ -52,7 +41,7 @@ extension String: CSVEncodable {
 }
 
 extension Date: CSVEncodable {
-    public func encode(configuration: CSVEncoderConfiguration) -> String {
+    func encode(configuration: CSVEncoderConfiguration) -> String {
         switch configuration.dateEncodingStrategy {
         case .deferredToDate:
             String(self.timeIntervalSinceReferenceDate)
@@ -67,26 +56,26 @@ extension Date: CSVEncodable {
 }
 
 extension UUID: CSVEncodable {
-    public func encode(configuration: CSVEncoderConfiguration) -> String {
+    func encode(configuration: CSVEncoderConfiguration) -> String {
         uuidString
     }
 }
 
 extension Int: CSVEncodable {
-    public func encode(configuration: CSVEncoderConfiguration) -> String {
+    func encode(configuration: CSVEncoderConfiguration) -> String {
         String(self)
     }
 }
 
 extension Double: CSVEncodable {
-    public func encode(configuration: CSVEncoderConfiguration) -> String {
+    func encode(configuration: CSVEncoderConfiguration) -> String {
         String(self)
     }
 }
 
 extension Bool: CSVEncodable {
-    public func encode(configuration: CSVEncoderConfiguration) -> String {
-        let (trueValue, falseValue) = configuration.boolEncodingStrategy.encodingValues
+    func encode(configuration: CSVEncoderConfiguration) -> String {
+        let (trueValue, falseValue) = configuration.encodingValues
 
         return self == true ? trueValue : falseValue
     }
@@ -120,14 +109,14 @@ extension CSVEncodable {
     }
 }
 
-public struct CSVEncoderConfiguration {
+struct CSVEncoderConfiguration {
     /// The strategy to use when encoding dates.
-    public private(set) var dateEncodingStrategy: DateEncodingStrategy = .iso8601
+    private(set) var dateEncodingStrategy: DateEncodingStrategy = .iso8601
     
     /// The strategy to use when encoding Boolean values.
-    public private(set) var boolEncodingStrategy: BoolEncodingStrategy = .trueFalse
+    private(set) var boolEncodingStrategy: BoolEncodingStrategy = .trueFalse
 
-    public init(
+    init(
         dateEncodingStrategy: DateEncodingStrategy = .iso8601,
         boolEncodingStrategy: BoolEncodingStrategy = .trueFalse
     ) {
@@ -136,7 +125,7 @@ public struct CSVEncoderConfiguration {
     }
     
     /// The strategy to use when encoding `Date` objects for CSV output.
-    public enum DateEncodingStrategy {
+    enum DateEncodingStrategy {
         case deferredToDate
         case iso8601
         case formatted(DateFormatter)
@@ -144,7 +133,7 @@ public struct CSVEncoderConfiguration {
     }
 
     /// The strategy to use when encoding `Bool` objects for CSV output.
-    public enum BoolEncodingStrategy {
+    enum BoolEncodingStrategy {
         case trueFalse
         case trueFalseUppercase
         case yesNo
@@ -152,12 +141,9 @@ public struct CSVEncoderConfiguration {
         case integer
         case custom(true: String, false: String)
     }
-    public static var `default`: CSVEncoderConfiguration = CSVEncoderConfiguration()
-}
-
-internal extension CSVEncoderConfiguration.BoolEncodingStrategy {
+    
     var encodingValues: (String, String) {
-        switch self {
+        switch boolEncodingStrategy {
         case .trueFalse:
             return ("true", "false")
         case .trueFalseUppercase:
@@ -172,13 +158,20 @@ internal extension CSVEncoderConfiguration.BoolEncodingStrategy {
             return (trueValue, falseValue)
         }
     }
+    
+    static var `default`: CSVEncoderConfiguration = CSVEncoderConfiguration()
 }
 
 struct CSVTable<Record> {
     /// A description of all the columns of the CSV file, order from left to right.
     private(set) var columns: [CSVColumn<Record>]
+    
     /// The set of configuration parameters to use while encoding attributes and the whole file.
     private(set) var configuration: CSVEncoderConfiguration
+    
+    private var headers: String {
+        columns.map { $0.header.escapedOutput(configuration: configuration) }.commaDelimited
+    }
     
     /// Create a CSV table definition.
     init(
@@ -190,16 +183,8 @@ struct CSVTable<Record> {
     }
     
     /// Constructs a CSV text file structure from the given rows of data.
-    func export(
-        rows: any Sequence<Record>
-    ) -> String {
+    func export(rows: any Sequence<Record>) -> String {
         ([headers] + allRows(rows: rows)).newlineDelimited
-    }
-
-    // MARK: -
-
-    private var headers: String {
-        columns.map { $0.header.escapedOutput(configuration: configuration) }.commaDelimited
     }
 
     private func allRows(rows: any Sequence<Record>) -> [String] {

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVEncoder.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVEncoder.swift
@@ -1,0 +1,259 @@
+//
+//  CSVEncoder.swift
+//  Basic-Car-Maintenance
+//
+//  https://github.com/mikaelacaron/Basic-Car-Maintenance
+//  See LICENSE for license information.
+//
+
+import Foundation
+import SwiftUI
+
+struct CSVFile {
+    var events: [MaintenanceEvent]
+    
+    func csvData() -> String {
+        let table = CSVTable<MaintenanceEvent>(
+            columns: [
+                CSVColumn("Date") { $0.date.formatted() },
+                CSVColumn("Vehicle Name", \.title),
+                CSVColumn("Notes", \.notes)
+            ], 
+            configuration: CSVEncoderConfiguration(dateEncodingStrategy: .iso8601) 
+        )
+        return table.export(rows: events)
+    }
+    
+    func generateCSVFile(vehicle: String) -> URL? {
+        // Get the path to the Documents Directory
+        let fileManager = FileManager.default
+            guard let documentsDirectory = fileManager.urls(
+                for: .documentDirectory, in: .userDomainMask).first else {
+                print("Failed to locate the Documents Directory.")
+                return nil
+            }
+        
+        // Create the file URL
+        let fileName = "\(vehicle)-MaintenanceReport"
+        let fileURL = documentsDirectory.appendingPathComponent(fileName).appendingPathExtension("csv")
+        
+        do {
+                // Save the CSV content to the file
+            try csvData().write(to: fileURL, atomically: true, encoding: .utf8)
+                print("File saved to \(fileURL)")
+                return fileURL
+            } catch {
+                print("Failed to save CSV file: \(error.localizedDescription)")
+                return nil
+            }
+    }
+}
+
+extension CSVFile: Transferable {
+  static var transferRepresentation: some TransferRepresentation {
+    DataRepresentation(exportedContentType: .commaSeparatedText) { file in
+      Data(file.csvData().utf8)
+    }
+  }
+}
+
+internal extension BidirectionalCollection where Element == String {
+    var commaDelimited: String { joined(separator: ",") }
+    var newlineDelimited: String { joined(separator: "\r\n") }
+}
+
+public struct CSVColumn<Record> {
+    /// The header name to use for the column in the CSV file's first row.
+    public private(set) var header: String
+   
+    public private(set) var attribute: (Record) -> CSVEncodable
+    
+    public init(
+        _ header: String,
+        attribute: @escaping (Record) -> CSVEncodable
+    ) {
+        self.header = header
+        self.attribute = attribute
+    }
+}
+
+extension CSVColumn {
+    public init<T: CSVEncodable> (
+        _ header: String,
+        _ keyPath: KeyPath<Record, T>
+    ) {
+        self.init(
+            header,
+            attribute: { $0[keyPath: keyPath] }
+        )
+    }
+}
+
+public protocol CSVEncodable {
+    /// Derive the string representation to be used in the exported CSV.
+    func encode(configuration: CSVEncoderConfiguration) -> String
+}
+
+extension String: CSVEncodable {
+    public func encode(configuration: CSVEncoderConfiguration) -> String {
+        self
+    }
+}
+
+extension Date: CSVEncodable {
+    public func encode(configuration: CSVEncoderConfiguration) -> String {
+        switch configuration.dateEncodingStrategy {
+        case .deferredToDate:
+            String(self.timeIntervalSinceReferenceDate)
+        case .iso8601:
+            ISO8601DateFormatter().string(from: self)
+        case .formatted(let dateFormatter):
+            dateFormatter.string(from: self)
+        case .custom(let customFunc):
+            customFunc(self)
+        }
+    }
+}
+
+extension UUID: CSVEncodable {
+    public func encode(configuration: CSVEncoderConfiguration) -> String {
+        uuidString
+    }
+}
+
+extension Int: CSVEncodable {
+    public func encode(configuration: CSVEncoderConfiguration) -> String {
+        String(self)
+    }
+}
+
+extension Double: CSVEncodable {
+    public func encode(configuration: CSVEncoderConfiguration) -> String {
+        String(self)
+    }
+}
+
+extension Bool: CSVEncodable {
+    public func encode(configuration: CSVEncoderConfiguration) -> String {
+        let (trueValue, falseValue) = configuration.boolEncodingStrategy.encodingValues
+
+        return self == true ? trueValue : falseValue
+    }
+}
+
+extension Optional: CSVEncodable where Wrapped: CSVEncodable {
+    public func encode(configuration: CSVEncoderConfiguration) -> String {
+        switch self {
+        case .none:
+            ""
+        case .some(let wrapped):
+            wrapped.encode(configuration: configuration)
+        }
+    }
+}
+
+extension CSVEncodable {
+    internal func escapedOutput(configuration: CSVEncoderConfiguration) -> String {
+        let output = self.encode(configuration: configuration)
+        if output.contains(",") || output.contains("\"") || output.contains(#"\n"#)
+            || output.hasPrefix(" ") || output.hasSuffix(" ") {
+            // Escape existing double quotes by doubling them
+            let escapedQuotes = output.replacingOccurrences(of: "\"", with: "\"\"")
+
+            // Wrap the string in double quotes
+            return "\"\(escapedQuotes)\""
+        } else {
+            // No special characters, return as is
+            return output
+        }
+    }
+}
+
+public struct CSVEncoderConfiguration {
+    /// The strategy to use when encoding dates.
+    public private(set) var dateEncodingStrategy: DateEncodingStrategy = .iso8601
+    
+    /// The strategy to use when encoding Boolean values.
+    public private(set) var boolEncodingStrategy: BoolEncodingStrategy = .trueFalse
+
+    public init(
+        dateEncodingStrategy: DateEncodingStrategy = .iso8601,
+        boolEncodingStrategy: BoolEncodingStrategy = .trueFalse
+    ) {
+        self.dateEncodingStrategy = dateEncodingStrategy
+        self.boolEncodingStrategy = boolEncodingStrategy
+    }
+    
+    /// The strategy to use when encoding `Date` objects for CSV output.
+    public enum DateEncodingStrategy {
+        case deferredToDate
+        case iso8601
+        case formatted(DateFormatter)
+        case custom(@Sendable (Date) -> String)
+    }
+
+    /// The strategy to use when encoding `Bool` objects for CSV output.
+    public enum BoolEncodingStrategy {
+        case trueFalse
+        case trueFalseUppercase
+        case yesNo
+        case yesNoUppercase
+        case integer
+        case custom(true: String, false: String)
+    }
+    public static var `default`: CSVEncoderConfiguration = CSVEncoderConfiguration()
+}
+
+internal extension CSVEncoderConfiguration.BoolEncodingStrategy {
+    var encodingValues: (String, String) {
+        switch self {
+        case .trueFalse:
+            return ("true", "false")
+        case .trueFalseUppercase:
+            return ("TRUE", "FALSE")
+        case .yesNo:
+            return ("yes", "no")
+        case .yesNoUppercase:
+            return ("YES", "NO")
+        case .integer:
+            return ("1", "0")
+        case .custom(let trueValue, let falseValue):
+            return (trueValue, falseValue)
+        }
+    }
+}
+
+public struct CSVTable<Record> {
+    /// A description of all the columns of the CSV file, order from left to right.
+    public private(set) var columns: [CSVColumn<Record>]
+    /// The set of configuration parameters to use while encoding attributes and the whole file.
+    public private(set) var configuration: CSVEncoderConfiguration
+    
+    /// Create a CSV table definition.
+    public init(
+        columns: [CSVColumn<Record>],
+        configuration: CSVEncoderConfiguration = .default
+    ) {
+        self.columns = columns
+        self.configuration = configuration
+    }
+    
+    /// Constructs a CSV text file structure from the given rows of data.
+    public func export(
+        rows: any Sequence<Record>
+    ) -> String {
+        ([headers] + allRows(rows: rows)).newlineDelimited
+    }
+
+    // MARK: -
+
+    private var headers: String {
+        columns.map { $0.header.escapedOutput(configuration: configuration) }.commaDelimited
+    }
+
+    private func allRows(rows: any Sequence<Record>) -> [String] {
+        rows.map { row in
+            columns.map { $0.attribute(row).escapedOutput(configuration: configuration) }.commaDelimited
+        }
+    }
+}

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVEncoder.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVEncoder.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-internal extension BidirectionalCollection where Element == String {
+extension BidirectionalCollection where Element == String {
     var commaDelimited: String { joined(separator: ",") }
     var newlineDelimited: String { joined(separator: "\r\n") }
 }
 
-public struct CSVColumn<Record> {
+struct CSVColumn<Record> {
     /// The header name to use for the column in the CSV file's first row.
-    public private(set) var header: String
+    private(set) var header: String
    
-    public private(set) var attribute: (Record) -> CSVEncodable
+    private(set) var attribute: (Record) -> CSVEncodable
     
-    public init(
+    init(
         _ header: String,
         attribute: @escaping (Record) -> CSVEncodable
     ) {
@@ -29,7 +29,7 @@ public struct CSVColumn<Record> {
 }
 
 extension CSVColumn {
-    public init<T: CSVEncodable> (
+    init<T: CSVEncodable> (
         _ header: String,
         _ keyPath: KeyPath<Record, T>
     ) {
@@ -40,13 +40,13 @@ extension CSVColumn {
     }
 }
 
-public protocol CSVEncodable {
+protocol CSVEncodable {
     /// Derive the string representation to be used in the exported CSV.
     func encode(configuration: CSVEncoderConfiguration) -> String
 }
 
 extension String: CSVEncodable {
-    public func encode(configuration: CSVEncoderConfiguration) -> String {
+    func encode(configuration: CSVEncoderConfiguration) -> String {
         self
     }
 }
@@ -93,7 +93,7 @@ extension Bool: CSVEncodable {
 }
 
 extension Optional: CSVEncodable where Wrapped: CSVEncodable {
-    public func encode(configuration: CSVEncoderConfiguration) -> String {
+    func encode(configuration: CSVEncoderConfiguration) -> String {
         switch self {
         case .none:
             ""
@@ -104,7 +104,7 @@ extension Optional: CSVEncodable where Wrapped: CSVEncodable {
 }
 
 extension CSVEncodable {
-    internal func escapedOutput(configuration: CSVEncoderConfiguration) -> String {
+    func escapedOutput(configuration: CSVEncoderConfiguration) -> String {
         let output = self.encode(configuration: configuration)
         if output.contains(",") || output.contains("\"") || output.contains(#"\n"#)
             || output.hasPrefix(" ") || output.hasSuffix(" ") {
@@ -174,14 +174,14 @@ internal extension CSVEncoderConfiguration.BoolEncodingStrategy {
     }
 }
 
-public struct CSVTable<Record> {
+struct CSVTable<Record> {
     /// A description of all the columns of the CSV file, order from left to right.
-    public private(set) var columns: [CSVColumn<Record>]
+    private(set) var columns: [CSVColumn<Record>]
     /// The set of configuration parameters to use while encoding attributes and the whole file.
-    public private(set) var configuration: CSVEncoderConfiguration
+    private(set) var configuration: CSVEncoderConfiguration
     
     /// Create a CSV table definition.
-    public init(
+    init(
         columns: [CSVColumn<Record>],
         configuration: CSVEncoderConfiguration = .default
     ) {
@@ -190,7 +190,7 @@ public struct CSVTable<Record> {
     }
     
     /// Constructs a CSV text file structure from the given rows of data.
-    public func export(
+    func export(
         rows: any Sequence<Record>
     ) -> String {
         ([headers] + allRows(rows: rows)).newlineDelimited

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVEncoder.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVEncoder.swift
@@ -7,55 +7,6 @@
 //
 
 import Foundation
-import SwiftUI
-
-struct CSVFile {
-    var events: [MaintenanceEvent]
-    
-    func csvData() -> String {
-        let table = CSVTable<MaintenanceEvent>(
-            columns: [
-                CSVColumn("Date") { $0.date.formatted() },
-                CSVColumn("Vehicle Name", \.title),
-                CSVColumn("Notes", \.notes)
-            ], 
-            configuration: CSVEncoderConfiguration(dateEncodingStrategy: .iso8601) 
-        )
-        return table.export(rows: events)
-    }
-    
-    func generateCSVFile(vehicle: String) -> URL? {
-        // Get the path to the Documents Directory
-        let fileManager = FileManager.default
-            guard let documentsDirectory = fileManager.urls(
-                for: .documentDirectory, in: .userDomainMask).first else {
-                print("Failed to locate the Documents Directory.")
-                return nil
-            }
-        
-        // Create the file URL
-        let fileName = "\(vehicle)-MaintenanceReport"
-        let fileURL = documentsDirectory.appendingPathComponent(fileName).appendingPathExtension("csv")
-        
-        do {
-                // Save the CSV content to the file
-            try csvData().write(to: fileURL, atomically: true, encoding: .utf8)
-                print("File saved to \(fileURL)")
-                return fileURL
-            } catch {
-                print("Failed to save CSV file: \(error.localizedDescription)")
-                return nil
-            }
-    }
-}
-
-extension CSVFile: Transferable {
-  static var transferRepresentation: some TransferRepresentation {
-    DataRepresentation(exportedContentType: .commaSeparatedText) { file in
-      Data(file.csvData().utf8)
-    }
-  }
-}
 
 internal extension BidirectionalCollection where Element == String {
     var commaDelimited: String { joined(separator: ",") }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVGeneratorView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVGeneratorView.swift
@@ -1,0 +1,74 @@
+//
+//  CSVGeneratorView.swift
+//  Basic-Car-Maintenance
+//
+//  https://github.com/mikaelacaron/Basic-Car-Maintenance
+//  See LICENSE for license information.
+//
+
+import Foundation
+import SwiftUI
+
+struct CSVGeneratorView: View {
+    let events: [MaintenanceEvent]
+    @Binding var csvFileURL: URL?
+    
+    var body: some View {
+        VStack {
+            List {
+                Grid {
+                    GridRow {
+                        Text("Date")
+                        Text("Vehicle Name")
+                        Text("Notes")
+                    }
+                    .bold()
+                    .frame(height: 40)
+                    Divider()
+                    ForEach(events) { event in
+                        GridRow {
+                            Text(event.date.formatted())
+                                .frame(maxWidth: 100, maxHeight: .infinity)
+                            Text(event.title)
+                            Text(event.notes)
+                        }
+                        if event != events.last {
+                            Divider()
+                        }
+                    }
+                }
+            }
+            VStack {
+                if let fileURL = csvFileURL {
+                    ShareLink(item: fileURL) {
+                        Label("Share", systemImage: SFSymbol.share)
+                    }
+                } else {
+                    Text("Error: Failed to save CSV file.")
+                        .foregroundColor(.red)
+                        .font(.subheadline)
+                }
+            }
+            .safeAreaPadding(.bottom)
+        }
+    }
+}
+
+#Preview {
+    CSVGeneratorView(
+        events: [
+            .init(
+                vehicleID: "1", 
+                title: "Creta", 
+                date: .now, 
+                notes: "Service"
+            ), 
+            .init(
+                vehicleID: "1", 
+                title: "Creta", 
+                date: .now,
+                notes: "Service")
+        ], 
+        csvFileURL: .constant(nil)
+    )
+}

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVGeneratorView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVGeneratorView.swift
@@ -15,42 +15,6 @@ struct CSVGeneratorView: View {
     let events: [MaintenanceEvent]
     let vehicleName: String
     
-    func csvData() -> String {
-        let table = CSVTable<MaintenanceEvent>(
-            columns: [
-                CSVColumn("Date") { $0.date.formatted() },
-                CSVColumn("Vehicle Name", \.title),
-                CSVColumn("Notes", \.notes)
-            ], 
-            configuration: CSVEncoderConfiguration(dateEncodingStrategy: .iso8601) 
-        )
-        return table.export(rows: events)
-    }
-    
-    func generateCSVFile(vehicle: String) -> URL? {
-        // Get the path to the Documents Directory
-        let fileManager = FileManager.default
-        guard let documentsDirectory = fileManager.urls(
-            for: .documentDirectory, in: .userDomainMask).first else {
-            print("Failed to locate the Documents Directory.")
-            return nil
-        }
-        
-        // Create the file URL
-        let fileName = "\(vehicle)-MaintenanceReport"
-        let fileURL = documentsDirectory.appendingPathComponent(fileName).appendingPathExtension("csv")
-        
-        do {
-            // Save the CSV content to the file
-            try csvData().write(to: fileURL, atomically: true, encoding: .utf8)
-            print("File saved to \(fileURL)")
-            return fileURL
-        } catch {
-            print("Failed to save CSV file: \(error.localizedDescription)")
-            return nil
-        }
-    }
-    
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -100,6 +64,39 @@ struct CSVGeneratorView: View {
                     }
                 }
             }
+        }
+    }
+    
+    private func csvData() -> String {
+        let table = CSVTable<MaintenanceEvent>(
+            columns: [
+                CSVColumn("Date") { $0.date.formatted() },
+                CSVColumn("Vehicle Name", \.title),
+                CSVColumn("Notes", \.notes)
+            ], 
+            configuration: CSVEncoderConfiguration(dateEncodingStrategy: .iso8601) 
+        )
+        return table.export(rows: events)
+    }
+    
+    private func generateCSVFile(vehicle: String) -> URL? {
+        let fileManager = FileManager.default
+        guard let documentsDirectory = fileManager.urls(
+            for: .documentDirectory, in: .userDomainMask).first else {
+            print("Failed to locate the Documents Directory.")
+            return nil
+        }
+        
+        let fileName = "\(vehicle)-MaintenanceReport"
+        let fileURL = documentsDirectory.appendingPathComponent(fileName).appendingPathExtension("csv")
+        
+        do {
+            try csvData().write(to: fileURL, atomically: true, encoding: .utf8)
+            print("File saved to \(fileURL)")
+            return fileURL
+        } catch {
+            print("Failed to save CSV file: \(error.localizedDescription)")
+            return nil
         }
     }
 }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVGeneratorView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVGeneratorView.swift
@@ -74,7 +74,7 @@ struct CSVGeneratorView: View {
                 CSVColumn("Vehicle Name", \.title),
                 CSVColumn("Notes", \.notes)
             ], 
-            configuration: CSVEncoderConfiguration(dateEncodingStrategy: .iso8601) 
+            configuration: CSVEncoderConfiguration() 
         )
         return table.export(rows: events)
     }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVGeneratorView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/CSVGeneratorView.swift
@@ -10,46 +10,96 @@ import Foundation
 import SwiftUI
 
 struct CSVGeneratorView: View {
+    @Environment(\.dismiss) var dismiss
+    
     let events: [MaintenanceEvent]
-    @Binding var csvFileURL: URL?
+    let vehicleName: String
+    
+    func csvData() -> String {
+        let table = CSVTable<MaintenanceEvent>(
+            columns: [
+                CSVColumn("Date") { $0.date.formatted() },
+                CSVColumn("Vehicle Name", \.title),
+                CSVColumn("Notes", \.notes)
+            ], 
+            configuration: CSVEncoderConfiguration(dateEncodingStrategy: .iso8601) 
+        )
+        return table.export(rows: events)
+    }
+    
+    func generateCSVFile(vehicle: String) -> URL? {
+        // Get the path to the Documents Directory
+        let fileManager = FileManager.default
+        guard let documentsDirectory = fileManager.urls(
+            for: .documentDirectory, in: .userDomainMask).first else {
+            print("Failed to locate the Documents Directory.")
+            return nil
+        }
+        
+        // Create the file URL
+        let fileName = "\(vehicle)-MaintenanceReport"
+        let fileURL = documentsDirectory.appendingPathComponent(fileName).appendingPathExtension("csv")
+        
+        do {
+            // Save the CSV content to the file
+            try csvData().write(to: fileURL, atomically: true, encoding: .utf8)
+            print("File saved to \(fileURL)")
+            return fileURL
+        } catch {
+            print("Failed to save CSV file: \(error.localizedDescription)")
+            return nil
+        }
+    }
     
     var body: some View {
-        VStack {
-            List {
-                Grid {
-                    GridRow {
-                        Text("Date")
-                        Text("Vehicle Name")
-                        Text("Notes")
-                    }
-                    .bold()
-                    .frame(height: 40)
-                    Divider()
-                    ForEach(events) { event in
+        NavigationStack {
+            VStack(spacing: 0) {
+                List {
+                    Grid(alignment: .leading, verticalSpacing: 5) {
                         GridRow {
-                            Text(event.date.formatted())
-                                .frame(maxWidth: 100, maxHeight: .infinity)
-                            Text(event.title)
-                            Text(event.notes)
+                            Text("Date")
+                            Text("Vehicle Name")
+                            Text("Notes")
                         }
-                        if event != events.last {
-                            Divider()
+                        .font(.headline)
+                        .frame(height: 50)
+                        
+                        Divider()
+                        
+                        ForEach(events) { event in
+                            GridRow(alignment: .firstTextBaseline) {
+                                Text(event.date.formatted())
+                                    .frame(maxWidth: 100, maxHeight: .infinity)
+                                Text(event.title)
+                                Text(event.notes)
+                            }
+                            .font(.subheadline)
+                            if event != events.last {
+                                Divider()
+                            }
                         }
                     }
                 }
-            }
-            VStack {
-                if let fileURL = csvFileURL {
-                    ShareLink(item: fileURL) {
-                        Label("Share", systemImage: SFSymbol.share)
+                VStack {
+                    if let fileURL = generateCSVFile(vehicle: vehicleName) {
+                        ShareLink(item: fileURL) {
+                            Label("Share", systemImage: SFSymbol.share)
+                        }
+                    } else {
+                        Text("Error: Failed to save CSV file.")
+                            .foregroundColor(.red)
+                            .font(.subheadline)
                     }
-                } else {
-                    Text("Error: Failed to save CSV file.")
-                        .foregroundColor(.red)
-                        .font(.subheadline)
+                }
+                .safeAreaPadding(.bottom)
+            }
+            .toolbar { 
+                ToolbarItem(placement: .topBarLeading) { 
+                    Button("Close") {
+                        dismiss()
+                    }
                 }
             }
-            .safeAreaPadding(.bottom)
         }
     }
 }
@@ -59,16 +109,10 @@ struct CSVGeneratorView: View {
         events: [
             .init(
                 vehicleID: "1", 
-                title: "Creta", 
+                title: "1st service", 
                 date: .now, 
-                notes: "Service"
-            ), 
-            .init(
-                vehicleID: "1", 
-                title: "Creta", 
-                date: .now,
-                notes: "Service")
-        ], 
-        csvFileURL: .constant(nil)
+                notes: "Maintenance and service"
+            )], 
+        vehicleName: ""
     )
 }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
@@ -22,7 +22,7 @@ struct ExportOptionsView: View {
     @State private var pdfDoc: PDFDocument?
     @State private var showingErrorAlert = false
     @State private var selectedOption: ExportOption?
-    @State private var showingExporter = false
+    @State private var showingCSVExporter = false
     
     private let dataSource: [Vehicle: [MaintenanceEvent]]
     
@@ -73,7 +73,7 @@ struct ExportOptionsView: View {
                                     isShowingThumbnail = true
                                 case .csv:
                                     selectedOption = nil
-                                    showingExporter = true
+                                    showingCSVExporter = true
                                 case .none:
                                     print("No option selected, do nothing")
                                 }
@@ -105,13 +105,11 @@ struct ExportOptionsView: View {
                     .presentationDetents([.medium])
                 }
             }
-            .sheet(isPresented: $showingExporter) { 
+            .sheet(isPresented: $showingCSVExporter) { 
                 if let selectedVehicle,
                    let events = self.dataSource[selectedVehicle] {
-                    CSVGeneratorView(
-                        events: events, 
-                        vehicleName: selectedVehicle.name
-                    ).presentationDetents([.medium])
+                    CSVGeneratorView(events: events, vehicleName: selectedVehicle.name)
+                        .presentationDetents([.medium])
                 }
             }
             .alert(

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
@@ -49,15 +49,15 @@ struct ExportOptionsView: View {
             .padding(.horizontal)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Menu(content: {
+                    Menu {
                         Picker("Export", selection: $selectedOption) {
-                            ForEach(ExportOption.allCases, id: \.self) { option in
+                            ForEach(ExportOption.allCases) { option in
                                 Text(option.rawValue).tag(option)
                             }
                         }
-                    }, label: {
+                    } label: {
                         Text("Export")
-                    })
+                    }
                     .onChange(of: selectedOption, { _, _ in
                         if let selectedVehicle,
                            let events = self.dataSource[selectedVehicle] {
@@ -75,7 +75,7 @@ struct ExportOptionsView: View {
                                     selectedOption = nil
                                     showingExporter = true
                                 case .none:
-                                    print("No option selected")
+                                    print("No option selected, do nothing")
                                 }
                             } else {
                                 showingErrorAlert = true

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
@@ -9,12 +9,22 @@
 import SwiftUI
 import PDFKit
 
+enum ExportOption: String, Identifiable, CaseIterable {
+    case pdf = "PDF"
+    case csv = "CSV"
+    var id: Self { self }
+}
+
 struct ExportOptionsView: View {
     @Environment(\.dismiss) var dismiss
     @State private var selectedVehicle: Vehicle?
     @State private var isShowingThumbnail = false
     @State private var pdfDoc: PDFDocument?
     @State private var showingErrorAlert = false
+    @State private var selectedOption: ExportOption?
+    @State private var showingExporter = false
+    @State private var csvFile: CSVFile?
+    @State private var csvFileURL: URL? 
     
     private let dataSource: [Vehicle: [MaintenanceEvent]]
     
@@ -41,22 +51,41 @@ struct ExportOptionsView: View {
             .padding(.horizontal)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Export") { 
+                    Menu(content: {
+                        Picker("Export", selection: $selectedOption) {
+                            ForEach(ExportOption.allCases, id: \.self) { option in
+                                Text(option.rawValue).tag(option)
+                            }
+                        }
+                    }, label: {
+                        Text("Export")
+                    })
+                    .onChange(of: selectedOption, { _, _ in
                         if let selectedVehicle,
                            let events = self.dataSource[selectedVehicle] {
-                            
                             if !events.isEmpty {
-                                let pdfGenerator = CarMaintenancePDFGenerator(
-                                    vehicleName: selectedVehicle.name,
-                                    events: events
-                                )
-                                self.pdfDoc = pdfGenerator.generatePDF() 
-                                isShowingThumbnail = true
+                                switch selectedOption {
+                                case .pdf:
+                                    selectedOption = nil
+                                    let pdfGenerator = CarMaintenancePDFGenerator(
+                                        vehicleName: selectedVehicle.name,
+                                        events: events
+                                    )
+                                    self.pdfDoc = pdfGenerator.generatePDF() 
+                                    isShowingThumbnail = true
+                                case .csv:
+                                    selectedOption = nil
+                                    showingExporter = true
+                                    let csv: CSVFile = CSVFile(events: events)
+                                    csvFileURL = csv.generateCSVFile(vehicle: selectedVehicle.name)
+                                case .none:
+                                    print("No option selected")
+                                }
                             } else {
                                 showingErrorAlert = true
                             }
                         }
-                    }
+                    })
                 }
             }
             .sheet(isPresented: $isShowingThumbnail) {
@@ -78,6 +107,15 @@ struct ExportOptionsView: View {
                         .safeAreaPadding(.bottom)
                     }
                     .presentationDetents([.medium])
+                }
+            }
+            .sheet(isPresented: $showingExporter) { 
+                if let selectedVehicle,
+                   let events = self.dataSource[selectedVehicle] {
+                    CSVGeneratorView(
+                        events: events, 
+                        csvFileURL: $csvFileURL
+                    ).presentationDetents([.medium])
                 }
             }
             .alert(

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/ExportOptionsView.swift
@@ -23,8 +23,6 @@ struct ExportOptionsView: View {
     @State private var showingErrorAlert = false
     @State private var selectedOption: ExportOption?
     @State private var showingExporter = false
-    @State private var csvFile: CSVFile?
-    @State private var csvFileURL: URL? 
     
     private let dataSource: [Vehicle: [MaintenanceEvent]]
     
@@ -76,8 +74,6 @@ struct ExportOptionsView: View {
                                 case .csv:
                                     selectedOption = nil
                                     showingExporter = true
-                                    let csv: CSVFile = CSVFile(events: events)
-                                    csvFileURL = csv.generateCSVFile(vehicle: selectedVehicle.name)
                                 case .none:
                                     print("No option selected")
                                 }
@@ -114,7 +110,7 @@ struct ExportOptionsView: View {
                    let events = self.dataSource[selectedVehicle] {
                     CSVGeneratorView(
                         events: events, 
-                        csvFileURL: $csvFileURL
+                        vehicleName: selectedVehicle.name
                     ).presentationDetents([.medium])
                 }
             }

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -1212,6 +1212,9 @@
         }
       }
     },
+    "Close" : {
+
+    },
     "Color" : {
       "localizations" : {
         "be" : {
@@ -2051,6 +2054,9 @@
           }
         }
       }
+    },
+    "Error: Failed to save CSV file." : {
+
     },
     "Export" : {
       "localizations" : {


### PR DESCRIPTION
# What it Does
* Closes #343 
* Added a picker to allow users to choose between PDF and CSV export options.
* Implemented functionality to generate a CSV file containing the maintenance events of selected vehicles.
* Integrated ShareLink to enable sharing of the generated CSV file.

# How I Tested
* Run the application
* Go to the dashboard and add a new maintenance event. This will enable the share button.
* Tap the share button to proceed to the vehicle selection screen.
* Select a vehicle, and a picker will appear.
* Choose CSV as the export format.
* See the result

# Screenshot

https://github.com/user-attachments/assets/fed33098-55a7-4e22-8ad3-2c5011388af2



