### PR TITLE
feat: Add vehicle-based filtering to DashboardView

### DIFF
--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -23,12 +23,22 @@ class DashboardViewModel {
     var vehicles = [Vehicle]()
     var searchText: String = ""
     var isLoading = false
+    var selectedVehicle: Vehicle?
 
     var sortedEvents: [MaintenanceEvent] {
         switch sortOption {
-        case .oldestToNewest: events.sorted { $0.date < $1.date }
-        case .newestToOldest: events.sorted { $0.date > $1.date }
-        case .custom: events
+        case .oldestToNewest:
+            return events.sorted { $0.date < $1.date }
+        case .newestToOldest:
+            return events.sorted { $0.date > $1.date }
+        case .vehicleType:
+            if let vehicle = selectedVehicle {
+                return events.filter { $0.vehicleID == vehicle.id }
+            } else {
+                return events
+            }
+        case .custom:
+            return events
         }
     }
     
@@ -180,7 +190,8 @@ extension DashboardViewModel {
     enum SortOption: Int, CaseIterable, Identifiable {
         case oldestToNewest = 0
         case newestToOldest = 1
-        case custom = 2
+        case vehicleType = 2
+        case custom = 3
         
         var id: Int {
             rawValue
@@ -200,6 +211,10 @@ extension DashboardViewModel {
                 LocalizedStringResource(
                     "Custom",
                     comment: "Sorting option that sorts items according to the user's preferences.")
+            case .vehicleType:
+                LocalizedStringResource(
+                    "By Vehicle",
+                    comment: "Sorting option that sorts items according to vehicle type.")
             }
         }
     }

--- a/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/ViewModels/DashboardViewModel.swift
@@ -23,7 +23,7 @@ class DashboardViewModel {
     var vehicles = [Vehicle]()
     var searchText: String = ""
     var isLoading = false
-    var selectedVehicle: Vehicle?
+    var selectedVehicleToSort: Vehicle? 
 
     var sortedEvents: [MaintenanceEvent] {
         switch sortOption {
@@ -31,8 +31,8 @@ class DashboardViewModel {
             return events.sorted { $0.date < $1.date }
         case .newestToOldest:
             return events.sorted { $0.date > $1.date }
-        case .vehicleType:
-            if let vehicle = selectedVehicle {
+        case .byVehicle:
+            if let vehicle = selectedVehicleToSort {
                 return events.filter { $0.vehicleID == vehicle.id }
             } else {
                 return events
@@ -190,7 +190,7 @@ extension DashboardViewModel {
     enum SortOption: Int, CaseIterable, Identifiable {
         case oldestToNewest = 0
         case newestToOldest = 1
-        case vehicleType = 2
+        case byVehicle = 2
         case custom = 3
         
         var id: Int {
@@ -211,10 +211,10 @@ extension DashboardViewModel {
                 LocalizedStringResource(
                     "Custom",
                     comment: "Sorting option that sorts items according to the user's preferences.")
-            case .vehicleType:
+            case .byVehicle:
                 LocalizedStringResource(
                     "By Vehicle",
-                    comment: "Sorting option that sorts items according to vehicle type.")
+                    comment: "Sorting option that sorts items according to the vehicle.")
             }
         }
     }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -15,6 +15,7 @@ struct DashboardView: View {
     @State private var viewModel: DashboardViewModel
     @State private var isShowingEditView = false
     @State private var isShowingExportOptionsView = false
+    @State private var isShowingVehicleSelection = false
     @State private var selectedMaintenanceEvent: MaintenanceEvent?
     
     init(userUID: String?) {
@@ -94,6 +95,12 @@ struct DashboardView: View {
                             systemImage: "wrench",
                             description: Text("Add your first maintenance")
                         )
+                    } else if viewModel.sortedEvents.isEmpty && viewModel.sortOption == .vehicleType {
+                        ContentUnavailableView(
+                            "No Results",
+                            systemImage: SFSymbol.magnifyingGlass,
+                            description: Text("No maintenance events found for the selected vehicle.")
+                        )
                     } else if viewModel.searchedEvents.isEmpty && !viewModel.searchText.isEmpty {
                         ContentUnavailableView("No results",
                                                systemImage: SFSymbol.magnifyingGlass,
@@ -123,12 +130,21 @@ struct DashboardView: View {
                     Menu {
                         Picker(selection: $viewModel.sortOption) {
                             ForEach(DashboardViewModel.SortOption.allCases) { option in
-                                Text(option.label)
-                                    .tag(option)
+                                if option != .vehicleType {
+                                    Text(option.label)
+                                        .tag(option)
+                                }
                             }
                         } label: {
                             EmptyView()
                         }
+                        
+                        Button(action: {
+                            viewModel.sortOption = .vehicleType
+                            isShowingVehicleSelection = true
+                        }, label: {
+                            Text(DashboardViewModel.SortOption.vehicleType.label)
+                        })
                     } label: {
                         Image(systemName: SFSymbol.filter)
                     }
@@ -182,6 +198,12 @@ struct DashboardView: View {
             .sheet(isPresented: $isShowingExportOptionsView) {
                 ExportOptionsView(dataSource: viewModel.vehiclesWithSortedEventsDict)
                     .presentationDetents([.medium])
+            }
+            .sheet(isPresented: $isShowingVehicleSelection) {
+                VehicleSelectionView(
+                    selectedVehicle: $viewModel.selectedVehicle,
+                    vehicles: viewModel.vehicles
+                )
             }
         }
         .onChange(of: scenePhase) { _, newScenePhase in

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/DashboardView.swift
@@ -95,7 +95,7 @@ struct DashboardView: View {
                             systemImage: "wrench",
                             description: Text("Add your first maintenance")
                         )
-                    } else if viewModel.sortedEvents.isEmpty && viewModel.sortOption == .vehicleType {
+                    } else if viewModel.sortedEvents.isEmpty && viewModel.sortOption == .byVehicle {
                         ContentUnavailableView(
                             "No Results",
                             systemImage: SFSymbol.magnifyingGlass,
@@ -130,7 +130,7 @@ struct DashboardView: View {
                     Menu {
                         Picker(selection: $viewModel.sortOption) {
                             ForEach(DashboardViewModel.SortOption.allCases) { option in
-                                if option != .vehicleType {
+                                if option != .byVehicle {
                                     Text(option.label)
                                         .tag(option)
                                 }
@@ -139,12 +139,12 @@ struct DashboardView: View {
                             EmptyView()
                         }
                         
-                        Button(action: {
-                            viewModel.sortOption = .vehicleType
+                        Button {
+                            viewModel.sortOption = .byVehicle
                             isShowingVehicleSelection = true
-                        }, label: {
-                            Text(DashboardViewModel.SortOption.vehicleType.label)
-                        })
+                        } label: {
+                            Text(DashboardViewModel.SortOption.byVehicle.label)
+                        }
                     } label: {
                         Image(systemName: SFSymbol.filter)
                     }
@@ -201,7 +201,7 @@ struct DashboardView: View {
             }
             .sheet(isPresented: $isShowingVehicleSelection) {
                 VehicleSelectionView(
-                    selectedVehicle: $viewModel.selectedVehicle,
+                    selectedVehicle: $viewModel.selectedVehicleToSort,
                     vehicles: viewModel.vehicles
                 )
             }

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/VehicleSelectionView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/VehicleSelectionView.swift
@@ -1,0 +1,40 @@
+//
+//  VehicleSelectionView.swift
+//  Basic-Car-Maintenance
+//
+//  https://github.com/mikaelacaron/Basic-Car-Maintenance
+//  See LICENSE for license information.
+//
+
+import SwiftUI
+
+struct VehicleSelectionView: View {
+    @Environment(\.dismiss) var dismiss
+    @Binding var selectedVehicle: Vehicle?
+    var vehicles: [Vehicle]
+
+    var body: some View {
+        NavigationView {
+            List {
+                Button(action: {
+                    selectedVehicle = nil
+                    dismiss()
+                }, label: {
+                    Text("All Vehicles")
+                        .fontWeight(.bold)
+                        .foregroundColor(.blue)
+                })
+                
+                ForEach(vehicles, id: \.id) { vehicle in
+                    Button(action: {
+                        selectedVehicle = vehicle
+                        dismiss()
+                    }, label: {
+                        Text(vehicle.name)
+                    })
+                }
+            }
+            .navigationTitle("Select Vehicle")
+        }
+    }
+}

--- a/Basic-Car-Maintenance/Shared/Dashboard/Views/VehicleSelectionView.swift
+++ b/Basic-Car-Maintenance/Shared/Dashboard/Views/VehicleSelectionView.swift
@@ -9,29 +9,31 @@
 import SwiftUI
 
 struct VehicleSelectionView: View {
-    @Environment(\.dismiss) var dismiss
     @Binding var selectedVehicle: Vehicle?
+    
     var vehicles: [Vehicle]
+    
+    @Environment(\.dismiss) var dismiss
 
     var body: some View {
         NavigationView {
-            List {
-                Button(action: {
+            List {  
+                Button {
                     selectedVehicle = nil
                     dismiss()
-                }, label: {
+                } label: {
                     Text("All Vehicles")
                         .fontWeight(.bold)
                         .foregroundColor(.blue)
-                })
+                }
                 
-                ForEach(vehicles, id: \.id) { vehicle in
-                    Button(action: {
+                ForEach(vehicles) { vehicle in
+                    Button {
                         selectedVehicle = vehicle
                         dismiss()
-                    }, label: {
+                    } label: {
                         Text(vehicle.name)
-                    })
+                    }
                 }
             }
             .navigationTitle("Select Vehicle")

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -944,7 +944,7 @@
       }
     },
     "By Vehicle" : {
-      "comment" : "Sorting option that sorts items according to vehicle type."
+      "comment" : "Sorting option that sorts items according to the vehicle."
     },
     "Can't Delete Last Vehicle" : {
       "localizations" : {

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -787,6 +787,9 @@
         }
       }
     },
+    "All Vehicles" : {
+
+    },
     "An Error Occurred" : {
       "comment" : "Title for alert shown when adding maintenance event fails",
       "localizations" : {
@@ -939,6 +942,9 @@
           }
         }
       }
+    },
+    "By Vehicle" : {
+      "comment" : "Sorting option that sorts items according to vehicle type."
     },
     "Can't Delete Last Vehicle" : {
       "localizations" : {
@@ -3586,6 +3592,9 @@
     "No events to export for this vehicle." : {
 
     },
+    "No maintenance events found for the selected vehicle." : {
+
+    },
     "No Name" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3666,6 +3675,9 @@
           }
         }
       }
+    },
+    "No Results" : {
+
     },
     "Notes" : {
       "comment" : "Maintenance event notes text field label",
@@ -4539,6 +4551,9 @@
           }
         }
       }
+    },
+    "Select Vehicle" : {
+
     },
     "Settings" : {
       "comment" : "Label to display settings.",


### PR DESCRIPTION
# What it Does
* Closes #354 
* Adds a feature that allows users to filter maintenance events by the selected vehicle

# How I Tested
* Run the application.
* Navigate to the Dashboard screen.
* Tap the Filter button in the toolbar.
* Select By Vehicle from the filter options.
* Choose a specific vehicle from the list and verify that only maintenance events for that vehicle are displayed.
* Repeat the above step, but select All Vehicles to ensure all events reappear.

# Screenshot and Preview

https://github.com/user-attachments/assets/b560d063-748b-418c-8606-9535fc4f9e8a

<img src="https://github.com/user-attachments/assets/44a6907c-888c-40bc-a789-ab6654106bd8" alt="empty-state" width="200"/>
