### PR TITLE
The line chart for the odometer is ready.

### DIFF
--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -5221,6 +5221,9 @@
         }
       }
     },
+    "Time Range" : {
+
+    },
     "Title" : {
       "comment" : "Maintenance event title text field header",
       "localizations" : {

--- a/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
@@ -112,7 +112,9 @@ struct OdometerView: View {
             }
             .sheet(isPresented: $viewModel.isShowingEditReadingView) {
                 if let selectedReading = viewModel.selectedReading {
-                    EditOdometerReadingView(selectedReading: selectedReading, vehicles: viewModel.vehicles) { updatedReading in viewModel.updateOdometerReading(updatedReading)
+                    // swiftlint:disable:next line_length
+                    EditOdometerReadingView(selectedReading: selectedReading, vehicles: viewModel.vehicles) { updatedReading in
+                        viewModel.updateOdometerReading(updatedReading)
                     }
                     .alert("An Error Occurred", isPresented: $viewModel.showEditErrorAlert) {
                         Button("OK", role: .cancel) { }

--- a/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
@@ -7,12 +7,14 @@
 //
 
 import SwiftUI
+import Charts
 
 struct OdometerView: View {
     @Environment(ActionService.self) var actionService
     
     @State private var viewModel: OdometerViewModel
-
+    @State private var selectedTimeRange: TimeRange = .years
+    
     init(userUID: String?) {
         self.init(viewModel: OdometerViewModel(userUID: userUID))
     }
@@ -20,35 +22,70 @@ struct OdometerView: View {
     fileprivate init(viewModel: OdometerViewModel) {
         self.viewModel = viewModel
     }
-
+    
     var body: some View {
         NavigationStack {
-            List {
-                ForEach(viewModel.readings) { reading in
-                    let vehicleName = viewModel.vehicles.first { $0.id == reading.vehicleID }?.name
-                    OdometerRowView(reading: reading, vehicleName: vehicleName)
-                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                            Button(role: .destructive) {
-                                Task {
-                                    await viewModel.deleteReading(reading)
-                                }
-                            } label: {
-                                Image(systemName: SFSymbol.trash)
-                            }
-                            
-                            Button {
-                                viewModel.selectedReading = reading
-                                viewModel.isShowingEditReadingView = true
-                            } label: {
-                                Label {
-                                    Text("Edit")
-                                } icon: {
-                                    Image(systemName: SFSymbol.pencil)
+            VStack {
+                Picker("Time Range", selection: $selectedTimeRange) {
+                    ForEach(TimeRange.allCases) { timeRange in
+                        Text(timeRange.rawValue).tag(timeRange)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+                
+                if !viewModel.readings.isEmpty {
+                    GroupBox {
+                        Chart {
+                            ForEach(viewModel.vehicles) { vehicle in
+                                let vehicleReadings = filteredReadings(for: vehicle)
+                                
+                                if !vehicleReadings.isEmpty {
+                                    ForEach(vehicleReadings) { reading in
+                                        LineMark(
+                                            x: .value("Date", reading.date, unit: .day),
+                                            y: .value("Odometer", reading.distance)
+                                        )
+                                    }
+                                    .foregroundStyle(by: .value("Vehicle", vehicle.name))
+                                    .symbol(by: .value("Vehicle", vehicle.name))
+                                    .interpolationMethod(.monotone)
                                 }
                             }
                         }
+                        .frame(height: 200)
+                    }
+                    .padding(.horizontal)
+                    .listRowSeparator(.hidden)
                 }
-                .listStyle(.inset)
+                
+                List {
+                    ForEach(viewModel.readings) { reading in
+                        let vehicleName = viewModel.vehicles.first { $0.id == reading.vehicleID }?.name
+                        OdometerRowView(reading: reading, vehicleName: vehicleName)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    Task {
+                                        await viewModel.deleteReading(reading)
+                                    }
+                                } label: {
+                                    Image(systemName: SFSymbol.trash)
+                                }
+                                
+                                Button {
+                                    viewModel.selectedReading = reading
+                                    viewModel.isShowingEditReadingView = true
+                                } label: {
+                                    Label {
+                                        Text("Edit")
+                                    } icon: {
+                                        Image(systemName: SFSymbol.pencil)
+                                    }
+                                }
+                            }
+                    }
+                    .listStyle(.inset)
+                }
             }
             .overlay {
                 if viewModel.readings.isEmpty {
@@ -75,9 +112,7 @@ struct OdometerView: View {
             }
             .sheet(isPresented: $viewModel.isShowingEditReadingView) {
                 if let selectedReading = viewModel.selectedReading {
-                    // swiftlint:disable:next line_length
-                    EditOdometerReadingView(selectedReading: selectedReading, vehicles: viewModel.vehicles) { updatedReading in
-                        viewModel.updateOdometerReading(updatedReading)
+                    EditOdometerReadingView(selectedReading: selectedReading, vehicles: viewModel.vehicles) { updatedReading in viewModel.updateOdometerReading(updatedReading)
                     }
                     .alert("An Error Occurred", isPresented: $viewModel.showEditErrorAlert) {
                         Button("OK", role: .cancel) { }
@@ -86,9 +121,35 @@ struct OdometerView: View {
                     }
                 }
             }
-
         }
         .analyticsView("\(Self.self)")
+    }
+    
+    // Helper function to filter readings based on the selected time range
+    private func filteredReadings(for vehicle: Vehicle) -> [OdometerReading] {
+        let vehicleReadings = viewModel.readings.filter { $0.vehicleID == vehicle.id }
+        
+        switch selectedTimeRange {
+        case .years:
+            return vehicleReadings
+        case .last30Days:
+            guard let lastReadingDate = vehicleReadings.map({ $0.date }).max() else {
+                return []
+            }
+            let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+            
+            // If the last reading is older than 30 days, include only the last reading
+            if lastReadingDate < thirtyDaysAgo {
+                if let lastReading = vehicleReadings.max(by: { $0.date < $1.date }) {
+                    return [lastReading]
+                } else {
+                    return []
+                }
+            } else {
+                // Include readings from the last 30 days
+                return vehicleReadings.filter { $0.date >= thirtyDaysAgo }
+            }
+        }
     }
     
     private func makeAddOdometerView() -> some View {
@@ -112,25 +173,50 @@ struct OdometerView: View {
     }
 }
 
+// Enum for the time range options in the picker
+enum TimeRange: String, CaseIterable, Identifiable {
+    case years = "All readings"
+    case last30Days = "Latest readings"
+    
+    var id: String { self.rawValue }
+}
+
 #Preview {
     let viewModel = OdometerViewModel(userUID: nil)
-    let firstCar = createVehicle(id: "id1", name: "My 1st car")
+    let firstCar = createVehicle(id: "id1", name: "1st car")
     let secondCar = createVehicle(id: "id2", name: "2nd Car")
     
     viewModel.vehicles.append(contentsOf: [firstCar, secondCar])
     
-    let firstReading = createReading(vehicleID: secondCar.id!,
+    let firstReading = createReading(vehicleID: firstCar.id!,
                                      date: "2024/10/18",
-                                     distance: 20)
+                                     distance: 35)
     let secondReading = createReading(vehicleID: firstCar.id!,
-                                     date: "2024/10/15",
-                                     distance: 1000)
-    
+                                      date: "2024/10/19",
+                                      distance: 564)
     let thirdReading = createReading(vehicleID: firstCar.id!,
+                                      date: "2024/11/23",
+                                      distance: 1000)
+    
+    let fourthReading = createReading(vehicleID: firstCar.id!,
+                                     date: "2024/11/30",
+                                     distance: 1024)
+    let fifthReading = createReading(vehicleID: secondCar.id!,
+                                      date: "2024/10/1",
+                                      distance: 1000)
+    
+    let sixthReading = createReading(vehicleID: secondCar.id!,
                                      date: "2024/10/13",
-                                     distance: 10)
-    viewModel.readings.append(contentsOf: [firstReading, secondReading, thirdReading])
-
+                                     distance: 1144)
+    let seventhReading = createReading(vehicleID: secondCar.id!,
+                                      date: "2024/10/15",
+                                      distance: 1412)
+    
+    let eighthReading = createReading(vehicleID: secondCar.id!,
+                                     date: "2024/11/13",
+                                     distance: 1542)
+    viewModel.readings.append(contentsOf: [firstReading, secondReading, thirdReading, fourthReading, fifthReading, sixthReading, seventhReading, eighthReading])
+    
     return OdometerView(viewModel: viewModel)
         .environment(ActionService.shared)
     
@@ -145,7 +231,7 @@ struct OdometerView: View {
                 vin: nil, 
                 licensePlateNumber: nil)
     }
-
+    
     func createReading(vehicleID: String, date: String, distance: Int) -> OdometerReading {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy/MM/dd"

--- a/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
@@ -218,6 +218,8 @@ enum TimeRange: String, CaseIterable, Identifiable {
     let eighthReading = createReading(vehicleID: secondCar.id!,
                                      date: "2024/11/13",
                                      distance: 1542)
+    
+    // swiftlint:disable:next line_length
     viewModel.readings.append(contentsOf: [firstReading, secondReading, thirdReading, fourthReading, fifthReading, sixthReading, seventhReading, eighthReading])
     
     return OdometerView(viewModel: viewModel)

--- a/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/Views/OdometerView.swift
@@ -13,7 +13,7 @@ struct OdometerView: View {
     @Environment(ActionService.self) var actionService
     
     @State private var viewModel: OdometerViewModel
-    @State private var selectedTimeRange: TimeRange = .years
+    @State private var selectedTimeRange: TimeRange = .all
     
     init(userUID: String?) {
         self.init(viewModel: OdometerViewModel(userUID: userUID))
@@ -127,12 +127,14 @@ struct OdometerView: View {
         .analyticsView("\(Self.self)")
     }
     
-    // Helper function to filter readings based on the selected time range
+    /// Filter the readins based on the selected time range, and if there are no readings in the last 30 days, just show the last reading.
+    /// - Parameter vehicle: The vehicle for these readings.
+    /// - Returns: The `[OdometerReading]`s for this vehicle in the time range.
     private func filteredReadings(for vehicle: Vehicle) -> [OdometerReading] {
         let vehicleReadings = viewModel.readings.filter { $0.vehicleID == vehicle.id }
         
         switch selectedTimeRange {
-        case .years:
+        case .all:
             return vehicleReadings
         case .last30Days:
             guard let lastReadingDate = vehicleReadings.map({ $0.date }).max() else {
@@ -148,7 +150,6 @@ struct OdometerView: View {
                     return []
                 }
             } else {
-                // Include readings from the last 30 days
                 return vehicleReadings.filter { $0.date >= thirtyDaysAgo }
             }
         }
@@ -175,9 +176,9 @@ struct OdometerView: View {
     }
 }
 
-// Enum for the time range options in the picker
+/// The time range options in the picker for the graph.
 enum TimeRange: String, CaseIterable, Identifiable {
-    case years = "All readings"
+    case all = "All readings"
     case last30Days = "Latest readings"
     
     var id: String { self.rawValue }
@@ -185,7 +186,7 @@ enum TimeRange: String, CaseIterable, Identifiable {
 
 #Preview {
     let viewModel = OdometerViewModel(userUID: nil)
-    let firstCar = createVehicle(id: "id1", name: "1st car")
+    let firstCar = createVehicle(id: "id1", name: "My 1st car")
     let secondCar = createVehicle(id: "id2", name: "2nd Car")
     
     viewModel.vehicles.append(contentsOf: [firstCar, secondCar])


### PR DESCRIPTION
# What it Does
Closes #353
It added line chart to the odometerview. I added a few more instances of odometer readings into the preview, so that it shows better in the previewer.


# How I Tested
After entering a new odometer reading the chart is displayed above the list. I was not able to test it all the way that I wanted because the firebase emulator wasn't working properly for me. Even though I tried restarting everything and I ran the emulator from within the backend and it started up properly in the terminal, however, when I tried running simulator it got this error.

11.4.0 - [FirebaseFirestore][I-FST000001] WatchStream (80b17503) Stream error: 'Unknown: An internal error has occurred, print and inspect the error details for more information.'

# Notes
* Anything else that should be noted about how you implemented this feature?

Interactive chart would be a good next step perhaps. It was in WWDC23 video here. https://developer.apple.com/videos/play/wwdc2023/10037/

# Screenshot
* Add a screenshot of your new feature! OR show a screen recording of it in action. (On the simulator press Cmd + R to record, and the stop button when done). **This video should be no longer than 30 seconds.**
![Simulator Screenshot - iPhone 16 - 2024-12-02 at 23 32 38](https://github.com/user-attachments/assets/ea7af965-a387-4f07-a8be-d01ac3c5160c)
