### PR TITLE
382 Fix GitHub Actions CI

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,4 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: SwiftLint
+        # To make SwiftLint treat all warnings as errors, add the --strict flag:
+        # run: swiftlint --strict --quiet --reporter github-actions-logging
         run: swiftlint --quiet --reporter github-actions-logging

--- a/build-docc.sh
+++ b/build-docc.sh
@@ -3,6 +3,7 @@
 xcrun xcodebuild docbuild \
     -scheme Basic-Car-Maintenance \
     -destination 'generic/platform=iOS Simulator' \
+    -skipPackagePluginValidation \
     -derivedDataPath "$PWD/.derivedData"
 
 xcrun docc process-archive transform-for-static-hosting \

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,6 +31,7 @@ platform :ios do
   		run_tests(
 			scheme: "Basic-Car-Maintenance",
 			only_testing: "Basic-Car-Maintenance-Tests",
+			xcargs: "-skipPackagePluginValidation",
 			device: "iPhone 16 Pro",
 			skip_build: true,
 			xcodebuild_formatter: 'xcbeautify -qq --is-ci --renderer github-actions',


### PR DESCRIPTION
## Description
Closes #382

## What it Does
- Adds `-skipPackagePluginValidation` to `xcodebuild` commands in `build-docc.sh` (DocC workflow) and Fastfile (unit tests workflow) to fix pipeline failures.
- The issue was caused by the `SwiftLintPlugins` package requiring interactive approval in CI, causing `xcodebuild` to fail.
- This change skips this validation, allowing unit tests and DocC workflows to run successfully. SwiftLint is not used for either of these actions.
- The `SwiftLint.yml` workflow and local Xcode linting remain unchanged, enforcing code style as configured.

## How I Tested
- Ran unit tests workflow in CI, confirming successful completion, and successfully failure for broken tests.
- Verified `docc.yml` workflow builds and deploys DocC documentation to GitHub Pages (tested on forked repo).
- Confirmed `SwiftLint.yml` workflow runs without changes, reporting linting issues as expected.

# Notes
* Added a comment to `swiftlint.yml` explaining how to enable SwiftLint’s **strict** mode in CI. This mode still shows rule breaks as warnings in Xcode, but it makes the GitHub Action fail, preventing any rule breaks from being merged.