### PR TITLE
Fix odometer reading not updating after edit

### DIFF
--- a/Basic-Car-Maintenance/Shared/Odometer/ViewModels/OdometerViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Odometer/ViewModels/OdometerViewModel.swift
@@ -96,8 +96,12 @@ class OdometerViewModel {
                     .document(id)
                     .setData(from: readingToUpdate)
                 
+                if let index = readings.firstIndex(where: { $0.id == id }) {
+                    readings[index] = readingToUpdate
+                }
+
                 AnalyticsService.shared.logEvent(.odometerUpdate)
-                
+
                 isShowingEditReadingView = false
             } catch {
                 errorMessage = error.localizedDescription


### PR DESCRIPTION
## Description
Fixes #297 

When editing an odometer reading, the `OdometerView` was still showing the old value after the `EditOdometerReadingView` was dismissed. This happened because `updateOdometerReading()` updated Firestore but did not update the local `readings` array.

## Changes
Updated `OdometerViewModel.updateOdometerReading()` to sync the local `readings` array after a successful Firestore write, following the same pattern already used in `deleteReading()`.

## How it works
After `setData(from:)` succeeds, the method now finds the reading by ID in the local array and replaces it with the updated value. This avoids an unnecessary network call while keeping the UI in sync.

## Testing
1. Add a vehicle and an odometer reading
2. Swipe left on the reading, tap Edit
3. Change the distance value and tap Update
4. The `OdometerView` now shows the updated value immediately

## Screenshots
N/A - Logic-only change, no UI modifications.