### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -28,7 +28,7 @@ jobs:
         echo "prev_week=$start_of_week..$end_of_week" >> "$GITHUB_ENV"
 
     - name: Run issue-metrics tool for issues and PRs opened last week
-      uses: github/issue-metrics@v3
+      uses: github-community-projects/issue-metrics@v3
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'mikaelacaron/Basic-Car-Maintenance created:${{ env.prev_week }}'
@@ -43,7 +43,7 @@ jobs:
           labels: weekly-report
     
     - name: Run issue-metrics tool for issues and PRs closed last week
-      uses: github/issue-metrics@v3
+      uses: github-community-projects/issue-metrics@v3
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'mikaelacaron/Basic-Car-Maintenance closed:${{ env.prev_week }}'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
